### PR TITLE
feat: build single-page quote generator

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,2 +1,594 @@
-<html>
+<!DOCTYPE html>
+<html lang="fr" class="h-full">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Générateur de devis</title>
+    <script src="https://cdn.tailwindcss.com?plugins=forms"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      body {
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+          sans-serif;
+      }
+      .line-clamp-3 {
+        display: -webkit-box;
+        -webkit-line-clamp: 3;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+      }
+      .quote-scroll {
+        max-height: calc(100vh - 320px);
+        scrollbar-width: thin;
+      }
+      .quote-scroll::-webkit-scrollbar {
+        width: 6px;
+      }
+      .quote-scroll::-webkit-scrollbar-thumb {
+        background: #0f766e;
+        border-radius: 999px;
+      }
+    </style>
+  </head>
+  <body class="min-h-full bg-slate-100 text-slate-900">
+    <header class="fixed inset-x-0 top-0 z-30 border-b border-white/20 bg-slate-900/90 backdrop-blur">
+      <nav class="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 text-sm font-medium text-white">
+        <div class="flex items-center gap-3">
+          <span class="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-500/90 text-lg font-semibold">DV</span>
+          <div>
+            <p class="text-base font-semibold tracking-wide">Deviseur Express</p>
+            <p class="text-xs text-white/70">Recherche & création de devis instantanée</p>
+          </div>
+        </div>
+        <div class="hidden items-center gap-8 md:flex">
+          <a href="#catalogue" class="transition hover:text-emerald-200">Catalogue</a>
+          <a href="#devis" class="transition hover:text-emerald-200">Devis en cours</a>
+        </div>
+        <button
+          id="generatePdfBtn"
+          class="inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-slate-900"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+            <path
+              fill-rule="evenodd"
+              d="M4 2.75A1.75 1.75 0 015.75 1h8.5A1.75 1.75 0 0116 2.75V6h.25A1.75 1.75 0 0118 7.75v8.5A1.75 1.75 0 0116.25 18h-8.5A1.75 1.75 0 016 16.25V16H3.75A1.75 1.75 0 012 14.25v-8.5A1.75 1.75 0 013.75 4H4v-1.25zm1.5 0V4h8V2.75a.25.25 0 00-.25-.25h-7.5a.25.25 0 00-.25.25zm2.5 11.5a.75.75 0 01.75-.75h4a.75.75 0 010 1.5h-4a.75.75 0 01-.75-.75zm.75-3a.75.75 0 000 1.5h4a.75.75 0 000-1.5h-4z"
+              clip-rule="evenodd"
+            />
+            <path d="M15.5 6H6v10.25c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V6z" />
+          </svg>
+          Générer le devis PDF
+        </button>
+      </nav>
+    </header>
+
+    <main class="px-6 pb-16 pt-28" id="catalogue">
+      <div class="mx-auto max-w-7xl">
+        <div class="grid gap-10 lg:grid-cols-[2fr,1fr] lg:items-start">
+          <section class="space-y-8">
+            <div class="rounded-3xl bg-white p-6 shadow-lg shadow-slate-900/5 ring-1 ring-black/5">
+              <h1 class="text-2xl font-semibold text-slate-900">Catalogue produits</h1>
+              <p class="mt-1 text-sm text-slate-500">
+                Recherchez par nom ou par référence pour ajouter des articles à votre devis.
+              </p>
+              <div class="mt-5">
+                <label for="searchInput" class="sr-only">Rechercher un produit</label>
+                <div class="relative">
+                  <span class="pointer-events-none absolute inset-y-0 left-4 flex items-center text-slate-400">
+                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="h-5 w-5">
+                      <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 105.4 5.4a7.5 7.5 0 0011.25 11.25z" />
+                    </svg>
+                  </span>
+                  <input
+                    id="searchInput"
+                    type="search"
+                    placeholder="Ex. rouleau, IDNEIGE, bac à chaussures..."
+                    class="w-full rounded-full border-0 bg-slate-100 py-3 pl-12 pr-4 text-base text-slate-900 shadow-inner shadow-slate-900/5 focus:outline-none focus:ring-2 focus:ring-emerald-400"
+                  />
+                </div>
+              </div>
+            </div>
+
+            <div id="productGrid" class="grid gap-6 md:grid-cols-2 xl:grid-cols-3"></div>
+            <div id="emptyState" class="hidden rounded-3xl border border-dashed border-slate-300 bg-white/60 p-12 text-center">
+              <h2 class="text-lg font-semibold text-slate-800">Aucun produit ne correspond à votre recherche</h2>
+              <p class="mt-2 text-sm text-slate-500">
+                Vérifiez l'orthographe ou essayez un autre mot-clé pour explorer le catalogue.
+              </p>
+            </div>
+          </section>
+
+          <aside id="devis" class="sticky top-28">
+            <div class="rounded-3xl bg-white/95 p-6 shadow-2xl shadow-emerald-500/10 ring-1 ring-black/5">
+              <div class="flex items-start justify-between gap-4">
+                <div>
+                  <h2 class="text-xl font-semibold text-slate-900">Devis en cours</h2>
+                  <p class="mt-1 text-xs uppercase tracking-wide text-emerald-600">Récapitulatif en temps réel</p>
+                </div>
+                <span id="quoteItemCount" class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">0 article</span>
+              </div>
+
+              <div class="quote-scroll mt-6 space-y-4 overflow-y-auto pr-2" id="quoteList"></div>
+
+              <div class="mt-6 space-y-4 border-t border-slate-200 pt-4">
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-slate-500">Total HT</span>
+                  <span id="totalHt" class="font-semibold text-slate-900">0,00 €</span>
+                </div>
+                <div class="flex items-center justify-between gap-3 text-sm">
+                  <label for="discountInput" class="text-slate-500">Remise (%)</label>
+                  <input
+                    id="discountInput"
+                    type="number"
+                    min="0"
+                    max="100"
+                    value="0"
+                    class="w-20 rounded-lg border border-slate-200 bg-white px-2 py-1 text-right text-sm focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  />
+                </div>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-slate-500">Total HT après remise</span>
+                  <span id="discountedTotal" class="font-semibold text-slate-900">0,00 €</span>
+                </div>
+                <div class="flex items-center justify-between text-sm">
+                  <span class="text-slate-500">TVA (20%)</span>
+                  <span id="vatAmount" class="font-semibold text-slate-900">0,00 €</span>
+                </div>
+                <div class="flex items-center justify-between text-base font-semibold text-slate-900">
+                  <span>Total TTC</span>
+                  <span id="totalTtc">0,00 €</span>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </main>
+
+    <template id="quoteLineTemplate">
+      <div class="group rounded-2xl border border-slate-200 bg-white/80 p-4 shadow-sm transition hover:border-emerald-300 hover:shadow-md">
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <p class="quote-name text-sm font-semibold text-slate-900"></p>
+            <p class="quote-reference text-xs text-slate-500"></p>
+          </div>
+          <button
+            type="button"
+            class="remove-line rounded-full bg-rose-100 p-2 text-rose-600 opacity-0 transition group-hover:opacity-100"
+            title="Retirer la ligne"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+              <path
+                fill-rule="evenodd"
+                d="M5.75 4A.75.75 0 016.5 3.25h7a.75.75 0 010 1.5h-.305l-.61 9.15a1.75 1.75 0 01-1.742 1.6H8.157a1.75 1.75 0 01-1.742-1.6L5.804 4.75H5.75a.75.75 0 010-1.5zm2.958 2.75a.75.75 0 00-1.5.05l.25 5a.75.75 0 001.5-.05l-.25-5zm4.084.05a.75.75 0 10-1.5-.05l-.25 5a.75.75 0 001.5.05l.25-5z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </button>
+        </div>
+        <div class="mt-3 flex items-center justify-between gap-3 text-xs text-slate-500">
+          <span class="quote-meta rounded-full bg-slate-100 px-2 py-1 font-medium"></span>
+          <span class="quote-total text-xs font-semibold uppercase tracking-wide text-emerald-600"></span>
+        </div>
+        <div class="mt-3 flex items-center justify-between">
+          <div class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-2 py-1 text-xs font-medium text-slate-700">
+            <button type="button" class="decrease inline-flex h-6 w-6 items-center justify-center rounded-full bg-white text-slate-600 shadow hover:bg-slate-200">−</button>
+            <span class="quote-quantity min-w-[2ch] text-center text-sm font-semibold text-slate-900"></span>
+            <button type="button" class="increase inline-flex h-6 w-6 items-center justify-center rounded-full bg-white text-slate-600 shadow hover:bg-slate-200">+</button>
+          </div>
+          <div class="text-right text-sm">
+            <p class="quote-unit-price font-medium text-slate-900"></p>
+            <p class="quote-line-total text-xs text-slate-500"></p>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <template id="productCardTemplate">
+      <article class="flex h-full flex-col overflow-hidden rounded-3xl bg-white shadow-lg shadow-slate-900/5 ring-1 ring-black/5 transition hover:-translate-y-1 hover:shadow-xl">
+        <div class="relative aspect-[4/3] w-full overflow-hidden">
+          <img class="h-full w-full object-cover" alt="Image produit" />
+          <div class="absolute inset-0 bg-gradient-to-t from-slate-900/30 to-transparent"></div>
+          <div class="reference-pill absolute left-4 top-4 rounded-full bg-white/90 px-3 py-1 text-xs font-semibold text-emerald-700"></div>
+        </div>
+        <div class="flex flex-1 flex-col gap-4 p-5">
+          <div class="space-y-2">
+            <h3 class="product-title text-lg font-semibold text-slate-900"></h3>
+            <p class="product-description text-sm text-slate-500 line-clamp-3"></p>
+          </div>
+          <div class="mt-auto flex items-center justify-between">
+            <div class="product-price text-lg font-semibold text-emerald-600"></div>
+            <button class="add-to-quote inline-flex items-center gap-2 rounded-full bg-emerald-500 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-emerald-500/20 transition hover:bg-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-300 focus:ring-offset-2 focus:ring-offset-white">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-4 w-4">
+                <path fill-rule="evenodd" d="M10 3a.75.75 0 01.75.75V9.25h5.5a.75.75 0 010 1.5h-5.5v5.5a.75.75 0 01-1.5 0v-5.5H3.25a.75.75 0 010-1.5h5.5V3.75A.75.75 0 0110 3z" clip-rule="evenodd" />
+              </svg>
+              Ajouter au devis
+            </button>
+          </div>
+        </div>
+      </article>
+    </template>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js" integrity="sha512-/xUuVbAOx5R16/fso+8t6n0A7gfbLbZD9PxhHsxiQpGITmlEsKq0S4w/p6kJlr7EiRaVOn5G1PbZNFQf+07dJg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.5.25/jspdf.plugin.autotable.min.js" integrity="sha512-e0pHg56k97X3CJidb8sRP/6zECVYgTbq+JdnGGGdcva9/+qIPN9XMY4bl7HgkEqECc20QU1vbKLMNSD61Ygbug==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script>
+      const csvPath = './catalogue/export_item.csv';
+      const VAT_RATE = 0.2;
+      const currencyFormatter = new Intl.NumberFormat('fr-FR', {
+        style: 'currency',
+        currency: 'EUR'
+      });
+
+      const state = {
+        products: [],
+        quote: new Map(),
+        discount: 0
+      };
+
+      const elements = {
+        productGrid: document.getElementById('productGrid'),
+        emptyState: document.getElementById('emptyState'),
+        searchInput: document.getElementById('searchInput'),
+        quoteList: document.getElementById('quoteList'),
+        quoteItemCount: document.getElementById('quoteItemCount'),
+        totalHt: document.getElementById('totalHt'),
+        discountedTotal: document.getElementById('discountedTotal'),
+        vatAmount: document.getElementById('vatAmount'),
+        totalTtc: document.getElementById('totalTtc'),
+        discountInput: document.getElementById('discountInput'),
+        generatePdfBtn: document.getElementById('generatePdfBtn')
+      };
+
+      const templates = {
+        productCard: document.getElementById('productCardTemplate'),
+        quoteLine: document.getElementById('quoteLineTemplate')
+      };
+
+      function parseCSV(text) {
+        const rows = [];
+        let current = [];
+        let value = '';
+        let inQuotes = false;
+
+        for (let i = 0; i < text.length; i++) {
+          const char = text[i];
+          if (char === '"') {
+            const nextChar = text[i + 1];
+            if (inQuotes && nextChar === '"') {
+              value += '"';
+              i++;
+            } else {
+              inQuotes = !inQuotes;
+            }
+          } else if (char === ';' && !inQuotes) {
+            current.push(value);
+            value = '';
+          } else if ((char === '\n' || char === '\r') && !inQuotes) {
+            if (char === '\r' && text[i + 1] === '\n') {
+              continue;
+            }
+            current.push(value);
+            rows.push(current);
+            current = [];
+            value = '';
+          } else {
+            value += char;
+          }
+        }
+        if (value || current.length) {
+          current.push(value);
+          rows.push(current);
+        }
+        return rows
+          .map((row) => row.map((cell) => cell.trim()))
+          .filter((row) => row.length && row.some((cell) => cell !== ''));
+      }
+
+      function parseNumber(value) {
+        if (!value) return 0;
+        const sanitized = value.replace(/\u00a0/g, ' ').replace(/\s/g, '').replace(',', '.');
+        const parsed = Number.parseFloat(sanitized);
+        return Number.isFinite(parsed) ? parsed : 0;
+      }
+
+      function normaliseProduct(row) {
+        const [id, category, unit, , , , , tarifPlein, reference, name, prixReference, description, link, image] = row;
+        const priceSource = parseNumber(prixReference) || parseNumber(tarifPlein);
+        const generatedId = id || reference || `tmp-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+        return {
+          id: generatedId,
+          reference: reference || 'N.C.',
+          name: name || 'Produit sans nom',
+          description: description || 'Description non fournie.',
+          price: priceSource,
+          unit: unit || '',
+          category: category || '',
+          link: link || '',
+          image:
+            image && image.startsWith('http')
+              ? image
+              : 'https://images.unsplash.com/photo-1582719478250-c89cae4dc85b?auto=format&fit=crop&w=800&q=80'
+        };
+      }
+
+      function updateProductGrid(products) {
+        elements.productGrid.innerHTML = '';
+        if (!products.length) {
+          elements.emptyState.classList.remove('hidden');
+          return;
+        }
+        elements.emptyState.classList.add('hidden');
+        const fragment = document.createDocumentFragment();
+        products.forEach((product) => {
+          const card = templates.productCard.content.cloneNode(true);
+          const badge = card.querySelector('.reference-pill');
+          const img = card.querySelector('img');
+          const title = card.querySelector('.product-title');
+          const desc = card.querySelector('.product-description');
+          const price = card.querySelector('.product-price');
+          const button = card.querySelector('.add-to-quote');
+
+          img.src = product.image;
+          img.onerror = () => {
+            img.src = 'https://via.placeholder.com/640x480.png?text=Image+indisponible';
+          };
+          badge.textContent = product.reference;
+          title.textContent = product.name;
+          desc.textContent = product.description || 'Description non fournie.';
+          price.textContent = currencyFormatter.format(product.price);
+          button.addEventListener('click', () => addToQuote(product));
+
+          fragment.appendChild(card);
+        });
+        elements.productGrid.appendChild(fragment);
+      }
+
+      function addToQuote(product) {
+        const existing = state.quote.get(product.id);
+        if (existing) {
+          existing.quantity += 1;
+        } else {
+          state.quote.set(product.id, {
+            product,
+            quantity: 1
+          });
+        }
+        renderQuote();
+      }
+
+      function removeFromQuote(productId) {
+        state.quote.delete(productId);
+        renderQuote();
+      }
+
+      function updateQuantity(productId, delta) {
+        const item = state.quote.get(productId);
+        if (!item) return;
+        const nextQuantity = item.quantity + delta;
+        if (nextQuantity <= 0) {
+          state.quote.delete(productId);
+        } else {
+          item.quantity = nextQuantity;
+        }
+        renderQuote();
+      }
+
+      function renderQuote() {
+        elements.quoteList.innerHTML = '';
+        if (!state.quote.size) {
+          elements.quoteList.innerHTML = `
+            <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
+              <p>Ajoutez des produits depuis le catalogue pour composer votre devis.</p>
+            </div>
+          `;
+          elements.quoteItemCount.textContent = '0 article';
+          updateTotals();
+          return;
+        }
+
+        let totalItems = 0;
+        const fragment = document.createDocumentFragment();
+        state.quote.forEach(({ product, quantity }) => {
+          totalItems += quantity;
+          const line = templates.quoteLine.content.cloneNode(true);
+          const titleEl = line.querySelector('.quote-name');
+          const referenceEl = line.querySelector('.quote-reference');
+          const chip = line.querySelector('.quote-meta');
+          const unitPriceEl = line.querySelector('.quote-unit-price');
+          const totalPriceEl = line.querySelector('.quote-line-total');
+          const quantityEl = line.querySelector('.quote-quantity');
+          const totalTag = line.querySelector('.quote-total');
+          const decreaseBtn = line.querySelector('.decrease');
+          const increaseBtn = line.querySelector('.increase');
+          const removeBtn = line.querySelector('.remove-line');
+
+          titleEl.textContent = product.name;
+          referenceEl.textContent = product.reference;
+          chip.textContent = product.unit ? `${product.unit} • ${product.category || 'Catégorie'}` : product.category || 'Article';
+          unitPriceEl.textContent = currencyFormatter.format(product.price);
+          totalPriceEl.textContent = `${currencyFormatter.format(product.price * quantity)} HT ligne`;
+          quantityEl.textContent = quantity;
+          totalTag.textContent = `Total : ${currencyFormatter.format(product.price * quantity)}`;
+
+          decreaseBtn.addEventListener('click', () => updateQuantity(product.id, -1));
+          increaseBtn.addEventListener('click', () => updateQuantity(product.id, 1));
+          removeBtn.addEventListener('click', () => removeFromQuote(product.id));
+
+          fragment.appendChild(line);
+        });
+        elements.quoteList.appendChild(fragment);
+        elements.quoteItemCount.textContent = `${totalItems} ${totalItems > 1 ? 'articles' : 'article'}`;
+        updateTotals();
+      }
+
+      function computeTotals() {
+        let totalHT = 0;
+        state.quote.forEach(({ product, quantity }) => {
+          totalHT += product.price * quantity;
+        });
+        const discountPercent = state.discount > 100 ? 100 : Math.max(0, state.discount);
+        const discountAmount = totalHT * (discountPercent / 100);
+        const discountedTotal = totalHT - discountAmount;
+        const vatAmount = discountedTotal * VAT_RATE;
+        const totalTTC = discountedTotal + vatAmount;
+        return {
+          totalHT,
+          discountPercent,
+          discountAmount,
+          discountedTotal,
+          vatAmount,
+          totalTTC
+        };
+      }
+
+      let latestTotals = computeTotals();
+
+      function updateTotals() {
+        latestTotals = computeTotals();
+        elements.totalHt.textContent = currencyFormatter.format(latestTotals.totalHT);
+        elements.discountedTotal.textContent = currencyFormatter.format(latestTotals.discountedTotal);
+        elements.vatAmount.textContent = currencyFormatter.format(latestTotals.vatAmount);
+        elements.totalTtc.textContent = currencyFormatter.format(latestTotals.totalTTC);
+      }
+
+      function handleSearchInput(event) {
+        const term = event.target.value.trim().toLowerCase();
+        if (!term) {
+          updateProductGrid(state.products);
+          return;
+        }
+        const results = state.products.filter((product) => {
+          return (
+            product.name.toLowerCase().includes(term) ||
+            product.reference.toLowerCase().includes(term) ||
+            product.category.toLowerCase().includes(term)
+          );
+        });
+        updateProductGrid(results);
+      }
+
+      function handleDiscountChange(event) {
+        const value = Number.parseFloat(event.target.value);
+        if (!Number.isFinite(value) || value < 0) {
+          state.discount = 0;
+          event.target.value = '0';
+        } else {
+          state.discount = Math.min(100, value);
+          event.target.value = state.discount;
+        }
+        updateTotals();
+      }
+
+      async function loadCatalogue() {
+        try {
+          const response = await fetch(csvPath);
+          if (!response.ok) {
+            throw new Error('Impossible de charger le catalogue');
+          }
+          const text = await response.text();
+          const rows = parseCSV(text);
+          const dataRows = rows.filter((row) => row[0] && /\d/.test(row[0]));
+          state.products = dataRows.map(normaliseProduct);
+          updateProductGrid(state.products);
+        } catch (error) {
+          console.error(error);
+          elements.productGrid.innerHTML = '';
+          elements.emptyState.classList.remove('hidden');
+          elements.emptyState.innerHTML = `
+            <h2 class="text-lg font-semibold text-rose-600">Erreur lors du chargement du catalogue</h2>
+            <p class="mt-2 text-sm text-slate-500">${error.message}</p>
+          `;
+        }
+      }
+
+      function generatePdf() {
+        if (!state.quote.size) {
+          alert('Ajoutez au moins un produit avant de générer le devis.');
+          return;
+        }
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF({ unit: 'pt', format: 'a4' });
+        const marginX = 40;
+        const marginY = 50;
+
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(22);
+        doc.text('DEVIS', marginX, marginY);
+
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(10);
+        doc.text('Société : ____________________________________________', marginX, marginY + 25);
+        doc.text('Adresse : ____________________________________________', marginX, marginY + 40);
+        doc.text('Client : ______________________________________________', marginX, marginY + 70);
+        doc.text('Date : ___________________', marginX, marginY + 85);
+
+        const body = [];
+        state.quote.forEach(({ product, quantity }) => {
+          body.push([
+            product.reference,
+            product.name,
+            quantity,
+            currencyFormatter.format(product.price),
+            currencyFormatter.format(product.price * quantity)
+          ]);
+        });
+
+        doc.autoTable({
+          startY: marginY + 110,
+          head: [['Référence', 'Désignation', 'Qté', 'Prix unitaire HT', 'Total HT']],
+          body,
+          styles: { fontSize: 9, cellPadding: 6 },
+          headStyles: { fillColor: [15, 118, 110], textColor: 255, halign: 'left' },
+          columnStyles: {
+            0: { cellWidth: 90 },
+            1: { cellWidth: 200 },
+            2: { halign: 'center', cellWidth: 40 },
+            3: { halign: 'right', cellWidth: 90 },
+            4: { halign: 'right', cellWidth: 90 }
+          }
+        });
+
+        const endY = doc.lastAutoTable.finalY + 20;
+        doc.setFontSize(11);
+        doc.setFont('helvetica', 'bold');
+        doc.text('Récapitulatif financier', marginX, endY);
+
+        const lineHeight = 16;
+        doc.setFont('helvetica', 'normal');
+        doc.text(`Total HT : ${currencyFormatter.format(latestTotals.totalHT)}`, marginX, endY + lineHeight);
+        doc.text(
+          `Remise (${latestTotals.discountPercent.toFixed(2)}%) : -${currencyFormatter.format(latestTotals.discountAmount)}`,
+          marginX,
+          endY + lineHeight * 2
+        );
+        doc.text(`Total HT après remise : ${currencyFormatter.format(latestTotals.discountedTotal)}`, marginX, endY + lineHeight * 3);
+        doc.text(`TVA (20%) : ${currencyFormatter.format(latestTotals.vatAmount)}`, marginX, endY + lineHeight * 4);
+        doc.setFont('helvetica', 'bold');
+        doc.text(`Total TTC : ${currencyFormatter.format(latestTotals.totalTTC)}`, marginX, endY + lineHeight * 5);
+
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(9);
+        doc.text('Conditions : ____________________________________________________________________________________', marginX, endY + lineHeight * 7);
+        doc.text('Signature : ____________________________________________', marginX, endY + lineHeight * 8.5);
+
+        doc.save('devis.pdf');
+      }
+
+      document.addEventListener('DOMContentLoaded', () => {
+        loadCatalogue();
+        elements.searchInput.addEventListener('input', handleSearchInput);
+        elements.discountInput.addEventListener('change', handleDiscountChange);
+        elements.discountInput.addEventListener('input', handleDiscountChange);
+        elements.generatePdfBtn.addEventListener('click', generatePdf);
+        renderQuote();
+      });
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- create a Tailwind-based single-page interface with fixed navigation, search, and product cards
- parse the CSV catalogue client-side to feed the product grid and interactive quote section with quantity controls, totals, and discounts
- integrate jsPDF and AutoTable to export the current quote with financial recap into a professionally formatted PDF

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e25fff7c108329a4adf71c8a6adbc9