### PR TITLE
Ajouter un filtrage par catégorie et améliorer l'expérience du devis

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -7,6 +7,17 @@
   color: #fff;
 }
 
+body {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: 1;
+  width: 100%;
+}
+
 .line-clamp-3 {
   display: -webkit-box;
   -webkit-line-clamp: 3;
@@ -37,9 +48,143 @@
   background: #94a3b8;
 }
 
+.category-filter {
+  position: relative;
+  width: 100%;
+  border-radius: 0.75rem;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.category-filter.has-selection {
+  border-color: #2563eb;
+  background: #eff6ff;
+}
+
+.category-filter[open] {
+  border-color: #2563eb;
+  box-shadow: 0 10px 30px -10px rgba(37, 99, 235, 0.35);
+}
+
+.category-filter-summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.category-filter.has-selection .category-filter-summary {
+  color: #1d4ed8;
+}
+
+.category-filter-summary::-webkit-details-marker {
+  display: none;
+}
+
+.category-filter-icon {
+  width: 1.125rem;
+  height: 1.125rem;
+  color: #64748b;
+  transition: transform 150ms ease;
+}
+
+.category-filter[open] .category-filter-icon {
+  transform: rotate(180deg);
+}
+
+.category-filter-panel {
+  position: absolute;
+  inset-inline-end: 0;
+  inset-block-start: calc(100% + 0.5rem);
+  min-width: min(22rem, 90vw);
+  max-height: 18rem;
+  overflow-y: auto;
+  border-radius: 0.75rem;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  box-shadow: 0 25px 50px -20px rgba(15, 23, 42, 0.45);
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  z-index: 20;
+}
+
+.category-filter-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.category-filter-options {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.category-filter-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.5rem;
+  transition: background-color 150ms ease;
+  font-size: 0.8125rem;
+  color: #1e293b;
+  cursor: pointer;
+}
+
+.category-filter-option:hover {
+  background-color: #eff6ff;
+}
+
+.category-filter-option input {
+  accent-color: #2563eb;
+}
+
+.category-filter-option--empty {
+  cursor: default;
+  color: #94a3b8;
+  pointer-events: none;
+}
+
+.category-filter-option--empty:hover {
+  background-color: transparent;
+}
+
 .product-card {
   position: relative;
   overflow: hidden;
+  border: 1px solid #e2e8f0;
+  transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+}
+
+.product-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.08), transparent 45%);
+  opacity: 0;
+  transition: opacity 200ms ease;
+  pointer-events: none;
+}
+
+.product-card:hover,
+.product-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 25px 40px -24px rgba(15, 23, 42, 0.55);
+  border-color: #bfdbfe;
+}
+
+.product-card:hover::after,
+.product-card:focus-within::after {
+  opacity: 1;
 }
 
 .product-image-frame {
@@ -48,6 +193,9 @@
   border-radius: 1rem;
   overflow: hidden;
   background: linear-gradient(135deg, #dbeafe, #f8fafc);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .product-image {
@@ -56,16 +204,15 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  opacity: 0;
-  transform: scale(1.05);
-  transition: opacity 200ms ease, transform 200ms ease;
+  opacity: 1;
+  transform: scale(1.02);
+  transition: transform 220ms ease;
   pointer-events: none;
 }
 
 .product-card:hover .product-image,
 .product-card:focus-within .product-image {
-  opacity: 1;
-  transform: scale(1);
+  transform: scale(1.08);
 }
 
 .product-card .product-reference-badge {
@@ -90,9 +237,268 @@
   gap: 1rem;
 }
 
+.quote-row {
+  display: flex;
+  flex-direction: column;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: #f8fafc;
+  color: #475569;
+  overflow: hidden;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.quote-row[data-expanded='true'] {
+  border-color: #2563eb;
+  box-shadow: 0 18px 38px -28px rgba(37, 99, 235, 0.65);
+}
+
+.quote-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  padding: 1rem 1.25rem;
+  border: none;
+  background: transparent;
+  font-size: 0.9375rem;
+  text-align: left;
+  cursor: pointer;
+  color: #0f172a;
+}
+
+.quote-summary:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+}
+
+.quote-summary-main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.quote-summary .quote-name {
+  color: #0f172a;
+}
+
+.quote-summary .quote-reference {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.quote-summary-quantity {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-variant-numeric: tabular-nums;
+  font-size: 0.875rem;
+  color: #1e293b;
+}
+
+.quote-summary-quantity [data-role='quantity-unit'] {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #2563eb;
+}
+
+.quote-summary-total {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.quote-summary-arrow {
+  width: 1.125rem;
+  height: 1.125rem;
+  transition: transform 160ms ease;
+  color: #64748b;
+}
+
+.quote-row[data-expanded='true'] .quote-summary-arrow {
+  transform: rotate(180deg);
+  color: #2563eb;
+}
+
+.quote-details {
+  display: none;
+  gap: 1.25rem;
+  padding: 0 1.25rem 1.25rem;
+}
+
+.quote-row[data-expanded='true'] .quote-details {
+  display: flex;
+  flex-direction: column;
+}
+
+.quote-details-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  font-size: 0.8125rem;
+  color: #475569;
+}
+
+.quote-details-body {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+  align-items: stretch;
+}
+
+.quote-quantity {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.quantity-unit-controls {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #fff;
+  padding: 0.5rem 0.75rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quantity-unit-controls button {
+  border: none;
+  background: transparent;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: #64748b;
+  cursor: pointer;
+  transition: color 150ms ease;
+}
+
+.quantity-unit-controls button:hover {
+  color: #0f172a;
+}
+
+.quantity-area-controls {
+  display: none;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.75rem;
+  background: #fff;
+  padding: 1rem;
+  color: #475569;
+  font-size: 0.8125rem;
+}
+
+.quantity-area-controls input {
+  border: 1px solid #d1d5db;
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.875rem;
+  color: #0f172a;
+}
+
+.quantity-area-controls input:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+}
+
+.quote-dimensions {
+  margin-top: 0.75rem;
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.quote-area {
+  margin-top: 0.25rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quote-area [data-role='quantity-unit'] {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #2563eb;
+  font-size: 0.75rem;
+}
+
+.quote-prices {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.quote-prices-label {
+  display: block;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  margin-bottom: 0.35rem;
+}
+
+.line-total-detail {
+  font-weight: 600;
+  color: #2563eb;
+}
+
+.quote-details .unit-price {
+  font-weight: 500;
+  color: #0f172a;
+}
+
+.remove-item {
+  border: none;
+  background: transparent;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #f43f5e;
+  cursor: pointer;
+  transition: color 150ms ease;
+}
+
+.remove-item:hover {
+  color: #be123c;
+}
+
+.quote-comment-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.8125rem;
+  color: #475569;
+}
+
+.quote-comment-block label {
+  font-weight: 600;
+}
+
 .quote-comment {
   resize: vertical;
   min-height: 3.5rem;
+  border: 1px solid #d1d5db;
+  border-radius: 0.75rem;
+  background: #fff;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: #0f172a;
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.quote-comment:focus {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+  border-color: #2563eb;
 }
 
 .general-comment {
@@ -111,7 +517,7 @@
   z-index: 50;
 }
 
-.modal-backdrop[data-open="true"] {
+.modal-backdrop[data-open='true'] {
   display: flex;
 }
 
@@ -143,6 +549,58 @@
   gap: 0.75rem;
 }
 
+.site-footer {
+  background: linear-gradient(135deg, #0f172a, #1e293b);
+  color: #e2e8f0;
+  margin-top: 4rem;
+  padding: 3rem 1.5rem 2rem;
+}
+
+.site-footer-content {
+  width: min(70rem, 100%);
+  margin: 0 auto 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.site-footer-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+}
+
+.site-footer-text {
+  font-size: 0.875rem;
+  color: #cbd5f5;
+}
+
+.site-footer-links {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.site-footer-links a {
+  font-size: 0.875rem;
+  color: #bfdbfe;
+  text-decoration: none;
+  transition: color 150ms ease;
+}
+
+.site-footer-links a:hover {
+  color: #ffffff;
+}
+
+.site-footer-bottom {
+  width: min(70rem, 100%);
+  margin: 0 auto;
+  font-size: 0.75rem;
+  text-align: center;
+  color: #94a3b8;
+}
+
 @media (max-width: 1024px) {
   .main-layout {
     flex-direction: column;
@@ -150,5 +608,23 @@
 
   .gutter.gutter-horizontal {
     display: none;
+  }
+
+  .category-filter-panel {
+    inset-inline-start: 0;
+  }
+
+  .quote-summary {
+    grid-template-columns: 1fr;
+    row-gap: 0.5rem;
+    align-items: flex-start;
+  }
+
+  .quote-summary-total {
+    justify-content: flex-start;
+  }
+
+  .quote-details {
+    padding-inline: 1rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -36,17 +36,34 @@
                 Parcourez le catalogue et ajoutez les articles souhaités directement à votre devis.
               </p>
             </div>
-            <div class="relative">
-              <label for="search" class="sr-only">Rechercher un produit</label>
-              <input
-                id="search"
-                type="search"
-                placeholder="Rechercher par nom ou référence..."
-                class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-11 pr-4 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
-              />
-              <svg class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
-              </svg>
+            <div class="flex flex-col gap-3 lg:flex-row lg:items-start lg:gap-4">
+              <div class="relative flex-1">
+                <label for="search" class="sr-only">Rechercher un produit</label>
+                <input
+                  id="search"
+                  type="search"
+                  placeholder="Rechercher par nom ou référence..."
+                  class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-11 pr-4 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                />
+                <svg class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
+                </svg>
+              </div>
+              <details id="category-filter" class="category-filter">
+                <summary class="category-filter-summary" role="button" aria-haspopup="listbox" aria-expanded="false">
+                  <span id="category-filter-label">Toutes les catégories</span>
+                  <svg class="category-filter-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
+                  </svg>
+                </summary>
+                <div class="category-filter-panel" role="listbox" aria-multiselectable="true">
+                  <div class="category-filter-actions">
+                    <p class="text-xs text-slate-500">Sélectionnez une ou plusieurs catégories.</p>
+                    <button id="category-filter-clear" type="button" class="text-xs font-semibold text-blue-600 hover:text-blue-700">Effacer</button>
+                  </div>
+                  <div id="category-filter-options" class="category-filter-options"></div>
+                </div>
+              </details>
             </div>
           </header>
           <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
@@ -139,57 +156,71 @@
     </template>
 
     <template id="quote-item-template">
-      <div class="quote-row flex flex-col gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-        <div class="flex items-start justify-between gap-2">
-          <div class="space-y-1">
-            <p class="quote-name font-semibold text-slate-900"></p>
-            <p class="quote-reference text-xs uppercase tracking-wide text-slate-400"></p>
-            <p class="quote-unit text-xs text-slate-500">
+      <div class="quote-row" data-expanded="false">
+        <button class="quote-summary" type="button" aria-expanded="false">
+          <span class="quote-summary-main">
+            <span class="quote-name"></span>
+            <span class="quote-reference"></span>
+          </span>
+          <span class="quote-summary-quantity">
+            <span data-role="quantity-value"></span>
+            <span data-role="quantity-unit"></span>
+          </span>
+          <span class="quote-summary-total">
+            <span class="line-total"></span>
+            <svg class="quote-summary-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.5a.75.75 0 0 1-1.08 0l-4.25-4.5a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+            </svg>
+          </span>
+        </button>
+        <div class="quote-details" hidden>
+          <div class="quote-details-header">
+            <p class="quote-unit">
               Unité de vente : <span data-role="quantity-unit"></span>
             </p>
+            <button class="remove-item" type="button">Retirer l'article</button>
           </div>
-          <button class="remove-item text-xs font-semibold text-rose-500 transition hover:text-rose-600">Retirer</button>
-        </div>
-        <div class="flex flex-wrap items-start gap-4">
-          <div class="flex flex-col gap-3">
-            <div class="quantity-unit-controls hidden flex items-center rounded-lg border border-slate-200 bg-white" data-mode="unit">
-              <button class="decrease px-2 py-1 text-base text-slate-500 transition hover:text-slate-700">−</button>
-              <span data-role="quantity-value" class="min-w-[2.5rem] text-center text-sm font-semibold text-slate-900"></span>
-              <button class="increase px-2 py-1 text-base text-slate-500 transition hover:text-slate-700">+</button>
-            </div>
-            <div class="quantity-area-controls hidden rounded-xl border border-slate-200 bg-white p-3" data-mode="area">
-              <div class="grid grid-cols-2 gap-3">
-                <label class="flex flex-col text-xs font-medium text-slate-500">
-                  Longueur (m)
-                  <input type="number" min="0" step="0.01" class="length-input mt-1 rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" />
-                </label>
-                <label class="flex flex-col text-xs font-medium text-slate-500">
-                  Largeur (m)
-                  <input type="number" min="0" step="0.01" class="width-input mt-1 rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" />
-                </label>
-              </div>
-              <p class="quote-dimensions mt-2 text-xs text-slate-500"></p>
-              <p class="quote-area mt-1 text-sm font-semibold text-slate-900">
-                Surface calculée :
+          <div class="quote-details-body">
+            <div class="quote-quantity">
+              <div class="quantity-unit-controls" data-mode="unit">
+                <button class="decrease" type="button" aria-label="Diminuer la quantité">−</button>
                 <span data-role="quantity-value"></span>
-                <span data-role="quantity-unit" class="text-xs uppercase tracking-wide text-blue-600"></span>
-              </p>
+                <button class="increase" type="button" aria-label="Augmenter la quantité">+</button>
+              </div>
+              <div class="quantity-area-controls" data-mode="area">
+                <div class="grid grid-cols-2 gap-3">
+                  <label class="flex flex-col text-xs font-medium text-slate-500">
+                    Longueur (m)
+                    <input type="number" min="0" step="0.01" class="length-input" />
+                  </label>
+                  <label class="flex flex-col text-xs font-medium text-slate-500">
+                    Largeur (m)
+                    <input type="number" min="0" step="0.01" class="width-input" />
+                  </label>
+                </div>
+                <p class="quote-dimensions"></p>
+                <p class="quote-area">
+                  Surface calculée :
+                  <span data-role="quantity-value"></span>
+                  <span data-role="quantity-unit"></span>
+                </p>
+              </div>
+            </div>
+            <div class="quote-prices">
+              <div>
+                <span class="quote-prices-label">PU HT</span>
+                <span class="unit-price"></span>
+              </div>
+              <div>
+                <span class="quote-prices-label">Total ligne</span>
+                <span class="line-total-detail"></span>
+              </div>
             </div>
           </div>
-          <div class="flex flex-1 flex-wrap items-center gap-4">
-            <div class="flex flex-col">
-              <span class="text-xs uppercase tracking-wide text-slate-400">PU HT</span>
-              <span class="unit-price font-medium text-slate-900"></span>
-            </div>
-            <div class="flex flex-col">
-              <span class="text-xs uppercase tracking-wide text-slate-400">Total ligne</span>
-              <span class="line-total font-semibold text-blue-600"></span>
-            </div>
+          <div class="quote-comment-block">
+            <label>Commentaire sur l'article</label>
+            <textarea class="quote-comment" placeholder="Ajoutez une précision qui apparaîtra dans le devis..."></textarea>
           </div>
-        </div>
-        <div class="flex flex-col gap-2">
-          <label class="text-xs font-medium text-slate-500">Commentaire sur l'article</label>
-          <textarea class="quote-comment w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez une précision qui apparaîtra dans le devis..."></textarea>
         </div>
       </div>
     </template>
@@ -210,5 +241,20 @@
         </div>
       </div>
     </div>
+
+    <footer class="site-footer">
+      <div class="site-footer-content">
+        <div>
+          <p class="site-footer-title">Deviseur Express</p>
+          <p class="site-footer-text">Solutions rapides pour créer vos devis professionnels.</p>
+        </div>
+        <div class="site-footer-links">
+          <a href="#catalogue-panel">Catalogue</a>
+          <a href="#quote-panel">Devis</a>
+          <a href="mailto:contact@deviseurexpress.fr">Contact</a>
+        </div>
+      </div>
+      <p class="site-footer-bottom">© <span id="footer-year"></span> Deviseur Express — Tous droits réservés.</p>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Résumé
- ajouter un sélecteur multichoix des catégories pour filtrer le catalogue produit
- afficher les vignettes produit et renforcer les effets visuels au survol
- compacter les lignes du devis avec ouverture détaillée et ajouter un pied de page visible

## Tests
- python3 -m http.server 8000 (aperçu manuel)

------
https://chatgpt.com/codex/tasks/task_b_68e27be2d4c08329a78fa68619e6ccbc