### PR TITLE
Add category filtering and collapsible quote rows

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -40,14 +40,39 @@
 .product-card {
   position: relative;
   overflow: hidden;
+  border: 1px solid #e2e8f0;
+  transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease;
+}
+
+.product-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), transparent 55%);
+  opacity: 0;
+  transition: opacity 220ms ease;
+  pointer-events: none;
+}
+
+.product-card:hover,
+.product-card:focus-within {
+  transform: translateY(-6px) scale(1.01);
+  box-shadow: 0 20px 35px -18px rgba(30, 64, 175, 0.65);
+  border-color: #bfdbfe;
+}
+
+.product-card:hover::after,
+.product-card:focus-within::after {
+  opacity: 1;
 }
 
 .product-image-frame {
   position: relative;
-  height: 9rem;
+  aspect-ratio: 4 / 3;
   border-radius: 1rem;
   overflow: hidden;
   background: linear-gradient(135deg, #dbeafe, #f8fafc);
+  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.15);
 }
 
 .product-image {
@@ -56,16 +81,30 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  opacity: 0;
-  transform: scale(1.05);
-  transition: opacity 200ms ease, transform 200ms ease;
-  pointer-events: none;
+  opacity: 1;
+  transform: scale(1);
+  transition: transform 260ms ease, filter 260ms ease;
 }
 
 .product-card:hover .product-image,
 .product-card:focus-within .product-image {
-  opacity: 1;
-  transform: scale(1);
+  transform: scale(1.05);
+  filter: saturate(1.05);
+}
+
+.product-card .product-category-badge {
+  position: absolute;
+  inset-inline-start: 0.75rem;
+  inset-block-start: 0.75rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  background-color: rgba(255, 255, 255, 0.92);
+  color: #1d4ed8;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px -12px rgba(15, 23, 42, 0.65);
 }
 
 .product-card .product-reference-badge {
@@ -88,6 +127,50 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.product-card .product-actions .product-price {
+  white-space: nowrap;
+}
+
+.category-filter-menu {
+  position: absolute;
+  inset-inline: 0;
+  margin-top: 0.5rem;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  background: #fff;
+  box-shadow: 0 20px 45px -20px rgba(15, 23, 42, 0.35);
+  display: none;
+  z-index: 40;
+}
+
+.category-filter-menu[data-open='true'] {
+  display: block;
+}
+
+.category-filter-option {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  font-size: 0.85rem;
+  color: #1e293b;
+  cursor: pointer;
+  transition: background-color 160ms ease, color 160ms ease;
+}
+
+.category-filter-option:hover,
+.category-filter-option:focus-within {
+  background-color: #eff6ff;
+  color: #1d4ed8;
+}
+
+.category-filter-option input[type='checkbox'] {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #2563eb;
 }
 
 .quote-comment {
@@ -141,6 +224,342 @@
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.quote-row {
+  display: flex;
+  flex-direction: column;
+  transition: border-color 180ms ease, box-shadow 180ms ease, background-color 180ms ease;
+}
+
+.quote-row + .quote-row {
+  margin-top: 1rem;
+}
+
+.quote-row[data-expanded='true'] {
+  background-color: #fff;
+  border-color: #bfdbfe;
+  box-shadow: 0 18px 35px -24px rgba(30, 64, 175, 0.55);
+}
+
+.quote-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+}
+
+.quote-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  flex: 1;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+.quote-toggle:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 2px;
+  border-radius: 0.75rem;
+}
+
+.quote-summary-title {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  text-align: left;
+}
+
+.quote-summary-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quote-summary-reference {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #64748b;
+}
+
+.quote-summary-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: #0f172a;
+}
+
+.quote-summary-quantity {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.25rem;
+  font-weight: 500;
+  color: #1e293b;
+}
+
+.quote-summary-total {
+  font-weight: 600;
+  color: #2563eb;
+  white-space: nowrap;
+}
+
+.quote-summary-icon {
+  width: 1rem;
+  height: 1rem;
+  color: #94a3b8;
+  transition: transform 160ms ease;
+}
+
+.quote-row[data-expanded='true'] .quote-summary-icon {
+  transform: rotate(180deg);
+  color: #2563eb;
+}
+
+.quote-summary .remove-item {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #f43f5e;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 160ms ease;
+}
+
+.quote-summary .remove-item:hover,
+.quote-summary .remove-item:focus-visible {
+  color: #be123c;
+  outline: none;
+}
+
+.quote-details {
+  border-top: 1px solid #e2e8f0;
+  padding: 0 1.25rem 1.25rem;
+  display: none;
+  gap: 1.25rem;
+  flex-direction: column;
+}
+
+.quote-row[data-expanded='true'] .quote-details {
+  display: flex;
+}
+
+.quote-details-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.quote-details-header .quote-name {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quote-details-header .quote-reference {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.quote-details-header .quote-unit {
+  font-size: 0.75rem;
+  color: #475569;
+}
+
+.quote-details-body {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.quote-quantity {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.quantity-unit-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #fff;
+  padding: 0.35rem 0.75rem;
+}
+
+.quantity-unit-controls button {
+  border: none;
+  background: none;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #475569;
+  cursor: pointer;
+  transition: color 160ms ease;
+}
+
+.quantity-unit-controls button:hover,
+.quantity-unit-controls button:focus-visible {
+  color: #1d4ed8;
+  outline: none;
+}
+
+.quantity-unit-controls span[data-role='quantity-value'] {
+  min-width: 2.5rem;
+  text-align: center;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quantity-area-controls {
+  border-radius: 1rem;
+  border: 1px solid #cbd5f5;
+  background: #fff;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.quantity-area-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+.quantity-area-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.quantity-area-grid input {
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5f5;
+  padding: 0.35rem 0.5rem;
+  font-size: 0.85rem;
+  color: #0f172a;
+}
+
+.quantity-area-grid input:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+}
+
+.quote-dimensions {
+  font-size: 0.75rem;
+  color: #64748b;
+}
+
+.quote-area {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quote-area span[data-role='quantity-unit'] {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #2563eb;
+}
+
+.quote-prices {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 1rem;
+  min-width: 12rem;
+}
+
+.quote-prices div {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.quote-prices span:first-child {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.quote-prices .unit-price {
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.quote-prices .line-total {
+  font-weight: 700;
+  color: #2563eb;
+}
+
+.quote-comment-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.quote-comment-block label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #475569;
+}
+
+.quote-comment-block .quote-comment {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid #cbd5f5;
+  background: #fff;
+  padding: 0.75rem;
+  font-size: 0.85rem;
+  color: #0f172a;
+  min-height: 4rem;
+}
+
+.quote-comment-block .quote-comment:focus-visible {
+  outline: 2px solid #2563eb;
+  outline-offset: 1px;
+}
+
+.site-footer {
+  margin-top: 4rem;
+  border-top: 1px solid #e2e8f0;
+  background: linear-gradient(135deg, #0f172a, #1d4ed8);
+  color: #fff;
+}
+
+.site-footer__content {
+  margin: 0 auto;
+  max-width: 120rem;
+  padding: 3rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.site-footer__title {
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.site-footer__subtitle {
+  font-size: 0.95rem;
+  max-width: 48rem;
+  color: rgba(226, 232, 240, 0.8);
 }
 
 @media (max-width: 1024px) {

--- a/index.html
+++ b/index.html
@@ -36,17 +36,50 @@
                 Parcourez le catalogue et ajoutez les articles souhaités directement à votre devis.
               </p>
             </div>
-            <div class="relative">
-              <label for="search" class="sr-only">Rechercher un produit</label>
-              <input
-                id="search"
-                type="search"
-                placeholder="Rechercher par nom ou référence..."
-                class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-11 pr-4 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
-              />
-              <svg class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
-              </svg>
+            <div class="flex flex-col gap-4 lg:flex-row">
+              <div class="relative flex-1">
+                <label for="search" class="sr-only">Rechercher un produit</label>
+                <input
+                  id="search"
+                  type="search"
+                  placeholder="Rechercher par nom ou référence..."
+                  class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-11 pr-4 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                />
+                <svg class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
+                </svg>
+              </div>
+              <div class="relative flex-1 lg:max-w-xs">
+                <button
+                  id="category-filter-toggle"
+                  type="button"
+                  class="flex w-full items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-blue-300 hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                >
+                  <span class="flex flex-col text-left">
+                    <span class="text-xs font-medium uppercase tracking-wide text-slate-400">Catégories</span>
+                    <span id="category-filter-label">Toutes les catégories</span>
+                  </span>
+                  <svg class="h-4 w-4 text-slate-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.185l3.71-3.955a.75.75 0 1 1 1.08 1.04l-4.24 4.52a.75.75 0 0 1-1.08 0l-4.24-4.52a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+                  </svg>
+                </button>
+                <div
+                  id="category-filter-menu"
+                  class="category-filter-menu"
+                  role="listbox"
+                  aria-labelledby="category-filter-toggle"
+                  aria-multiselectable="true"
+                >
+                  <p class="px-4 pt-3 text-xs font-medium uppercase tracking-wide text-slate-400">Sélectionnez une ou plusieurs catégories</p>
+                  <div id="category-filter-options" class="mt-2 max-h-60 overflow-y-auto px-2 pb-2"></div>
+                  <div class="flex items-center justify-between gap-2 border-t border-slate-200 px-4 py-3">
+                    <button type="button" id="category-filter-clear" class="text-xs font-semibold text-slate-500 transition hover:text-rose-500">Réinitialiser</button>
+                    <button type="button" id="category-filter-close" class="rounded-lg bg-blue-600 px-3 py-1 text-xs font-semibold text-white transition hover:bg-blue-700">Fermer</button>
+                  </div>
+                </div>
+              </div>
             </div>
           </header>
           <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
@@ -108,17 +141,18 @@
     </main>
 
     <template id="product-card-template">
-      <article class="product-card group flex h-full flex-col rounded-2xl bg-white p-5 shadow-sm transition hover:-translate-y-1 hover:shadow-md focus-within:-translate-y-1 focus-within:shadow-md">
+      <article class="product-card group flex h-full flex-col rounded-2xl bg-white p-5 shadow-sm transition focus-within:-translate-y-1 focus-within:shadow-xl">
         <div class="product-image-frame">
+          <span class="product-category-badge"></span>
           <img class="product-image" alt="" />
           <div class="product-reference-badge">
             <span class="product-reference"></span>
           </div>
         </div>
         <div class="mt-4 flex flex-1 flex-col gap-4">
-          <div class="flex-1">
+          <div class="flex-1 space-y-3">
             <h3 class="product-name text-base font-semibold text-slate-900"></h3>
-            <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
+            <p class="product-description line-clamp-3 text-sm text-slate-500"></p>
           </div>
           <div class="product-actions">
             <div>
@@ -139,57 +173,75 @@
     </template>
 
     <template id="quote-item-template">
-      <div class="quote-row flex flex-col gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-600">
-        <div class="flex items-start justify-between gap-2">
-          <div class="space-y-1">
-            <p class="quote-name font-semibold text-slate-900"></p>
-            <p class="quote-reference text-xs uppercase tracking-wide text-slate-400"></p>
-            <p class="quote-unit text-xs text-slate-500">
+      <div class="quote-row rounded-xl border border-slate-200 bg-slate-50 text-sm text-slate-600" data-expanded="false">
+        <div class="quote-summary">
+          <button class="quote-toggle" type="button" aria-expanded="false">
+            <span class="quote-summary-title">
+              <span class="quote-summary-name"></span>
+              <span class="quote-summary-reference"></span>
+            </span>
+            <span class="quote-summary-meta">
+              <span class="quote-summary-quantity">
+                <span data-role="quantity-value"></span>
+                <span data-role="quantity-unit"></span>
+              </span>
+              <span class="quote-summary-total"></span>
+              <svg class="quote-summary-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                <path fill-rule="evenodd" d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.185l3.71-3.955a.75.75 0 1 1 1.08 1.04l-4.24 4.52a.75.75 0 0 1-1.08 0l-4.24-4.52a.75.75 0 0 1 .02-1.06Z" clip-rule="evenodd" />
+              </svg>
+            </span>
+          </button>
+          <button class="remove-item" type="button">Retirer</button>
+        </div>
+        <div class="quote-details">
+          <div class="quote-details-header">
+            <p class="quote-name"></p>
+            <p class="quote-reference"></p>
+            <p class="quote-unit">
               Unité de vente : <span data-role="quantity-unit"></span>
             </p>
           </div>
-          <button class="remove-item text-xs font-semibold text-rose-500 transition hover:text-rose-600">Retirer</button>
-        </div>
-        <div class="flex flex-wrap items-start gap-4">
-          <div class="flex flex-col gap-3">
-            <div class="quantity-unit-controls hidden flex items-center rounded-lg border border-slate-200 bg-white" data-mode="unit">
-              <button class="decrease px-2 py-1 text-base text-slate-500 transition hover:text-slate-700">−</button>
-              <span data-role="quantity-value" class="min-w-[2.5rem] text-center text-sm font-semibold text-slate-900"></span>
-              <button class="increase px-2 py-1 text-base text-slate-500 transition hover:text-slate-700">+</button>
-            </div>
-            <div class="quantity-area-controls hidden rounded-xl border border-slate-200 bg-white p-3" data-mode="area">
-              <div class="grid grid-cols-2 gap-3">
-                <label class="flex flex-col text-xs font-medium text-slate-500">
-                  Longueur (m)
-                  <input type="number" min="0" step="0.01" class="length-input mt-1 rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" />
-                </label>
-                <label class="flex flex-col text-xs font-medium text-slate-500">
-                  Largeur (m)
-                  <input type="number" min="0" step="0.01" class="width-input mt-1 rounded-md border border-slate-300 px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" />
-                </label>
-              </div>
-              <p class="quote-dimensions mt-2 text-xs text-slate-500"></p>
-              <p class="quote-area mt-1 text-sm font-semibold text-slate-900">
-                Surface calculée :
+          <div class="quote-details-body">
+            <div class="quote-quantity">
+              <div class="quantity-unit-controls hidden" data-mode="unit">
+                <button class="decrease" type="button" aria-label="Diminuer la quantité">−</button>
                 <span data-role="quantity-value"></span>
-                <span data-role="quantity-unit" class="text-xs uppercase tracking-wide text-blue-600"></span>
-              </p>
+                <button class="increase" type="button" aria-label="Augmenter la quantité">+</button>
+              </div>
+              <div class="quantity-area-controls hidden" data-mode="area">
+                <div class="quantity-area-grid">
+                  <label>
+                    Longueur (m)
+                    <input type="number" min="0" step="0.01" class="length-input" />
+                  </label>
+                  <label>
+                    Largeur (m)
+                    <input type="number" min="0" step="0.01" class="width-input" />
+                  </label>
+                </div>
+                <p class="quote-dimensions"></p>
+                <p class="quote-area">
+                  Surface calculée :
+                  <span data-role="quantity-value"></span>
+                  <span data-role="quantity-unit"></span>
+                </p>
+              </div>
+            </div>
+            <div class="quote-prices">
+              <div>
+                <span>PU HT</span>
+                <span class="unit-price"></span>
+              </div>
+              <div>
+                <span>Total ligne</span>
+                <span class="line-total"></span>
+              </div>
             </div>
           </div>
-          <div class="flex flex-1 flex-wrap items-center gap-4">
-            <div class="flex flex-col">
-              <span class="text-xs uppercase tracking-wide text-slate-400">PU HT</span>
-              <span class="unit-price font-medium text-slate-900"></span>
-            </div>
-            <div class="flex flex-col">
-              <span class="text-xs uppercase tracking-wide text-slate-400">Total ligne</span>
-              <span class="line-total font-semibold text-blue-600"></span>
-            </div>
+          <div class="quote-comment-block">
+            <label>Commentaire sur l'article</label>
+            <textarea class="quote-comment" placeholder="Ajoutez une précision qui apparaîtra dans le devis..."></textarea>
           </div>
-        </div>
-        <div class="flex flex-col gap-2">
-          <label class="text-xs font-medium text-slate-500">Commentaire sur l'article</label>
-          <textarea class="quote-comment w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez une précision qui apparaîtra dans le devis..."></textarea>
         </div>
       </div>
     </template>
@@ -210,5 +262,11 @@
         </div>
       </div>
     </div>
+    <footer class="site-footer">
+      <div class="site-footer__content">
+        <p class="site-footer__title">Deviseur Express</p>
+        <p class="site-footer__subtitle">Solutions rapides pour des devis précis et professionnels.</p>
+      </div>
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a multi-select category dropdown to filter the catalogue and keep the product grid in sync
- refresh product cards with visible thumbnails and hover styling for a more visual catalogue
- collapse quote items into concise summaries with expandable details and keep a branded footer visible

## Testing
- not run (static front-end changes)


------
https://chatgpt.com/codex/tasks/task_b_68e27be2d4c08329a78fa68619e6ccbc