### PR TITLE
Refonte de la gestion des remises et filtrage des unités

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -89,23 +89,6 @@
   backdrop-filter: blur(4px);
 }
 
-.product-thumbnail {
-  position: relative;
-  flex-shrink: 0;
-  width: 4.5rem;
-  height: 4.5rem;
-  border-radius: 1rem;
-  overflow: hidden;
-  background: #e2e8f0;
-  box-shadow: inset 0 1px 1px rgba(148, 163, 184, 0.4);
-}
-
-.product-thumbnail-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
 .product-category-badge {
   display: inline-flex;
   align-items: center;
@@ -130,6 +113,60 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.product-prices {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+.product-prices .product-price-original {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-decoration: line-through;
+}
+
+.product-prices .product-price-current {
+  margin: 0;
+}
+
+.price-values {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.2rem;
+}
+
+.price-values .price-original {
+  font-size: 0.75rem;
+  color: #94a3b8;
+  text-decoration: line-through;
+}
+
+.price-values .price-current {
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.summary-total {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.15rem;
+}
+
+.summary-total .price-original {
+  font-size: 0.7rem;
+  color: #94a3b8;
+  text-decoration: line-through;
+}
+
+.summary-total .price-current {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #1d4ed8;
 }
 
 .category-filter-menu {
@@ -365,19 +402,14 @@
   color: #94a3b8;
 }
 
-.summary-quantity,
-.summary-total {
+.summary-quantity {
+  margin-left: auto;
   font-size: 0.75rem;
   font-weight: 600;
   color: #0f172a;
 }
 
-.summary-quantity {
-  margin-left: auto;
-}
-
 .summary-total {
-  color: #1d4ed8;
   margin-left: 0.5rem;
 }
 
@@ -594,5 +626,90 @@
 
   .gutter.gutter-horizontal {
     display: none;
+  }
+
+  .product-card .product-actions {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  .product-card .product-actions > .flex {
+    width: 100%;
+  }
+
+  .product-card .product-actions button {
+    width: 100%;
+  }
+
+  .price-column {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .nav-actions {
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+
+  .nav-actions .discount-input {
+    flex: 1 1 auto;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nav-actions .discount-input {
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .nav-actions .discount-input input {
+    width: 100%;
+  }
+
+  .nav-actions #generate-pdf {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .quote-summary {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+  }
+
+  .toggle-details {
+    align-items: flex-start;
+  }
+
+  .summary-quantity {
+    margin-left: 0;
+  }
+
+  .summary-total {
+    margin-left: 0;
+    align-items: flex-start;
+  }
+
+  .price-column {
+    width: 100%;
+  }
+
+  .quote-row {
+    padding: 0.85rem;
+  }
+
+  .quote-summary-panel {
+    padding: 1.25rem;
+  }
+
+  .site-footer .footer-inner {
+    padding: 2.5rem 1.25rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   </head>
   <body class="bg-slate-100 text-slate-800 min-h-screen">
     <nav class="fixed inset-x-0 top-0 z-40 bg-white shadow-sm">
-      <div class="mx-auto flex w-full max-w-[120rem] items-center justify-between px-4 py-4">
+      <div class="mx-auto flex w-full max-w-[120rem] flex-wrap items-center justify-between gap-4 px-4 py-4 lg:flex-nowrap">
         <div class="flex items-center gap-3">
           <div class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white font-semibold">DV</div>
           <div>
@@ -21,9 +21,26 @@
             <p class="text-sm text-slate-500">Créez vos devis en quelques clics</p>
           </div>
         </div>
-        <button id="generate-pdf" class="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
-          Générer le devis PDF
-        </button>
+        <div class="nav-actions flex flex-1 flex-wrap items-center justify-end gap-3 sm:flex-nowrap">
+          <div class="discount-input flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 shadow-inner">
+            <label for="discount" class="text-xs font-semibold uppercase tracking-wide text-slate-500">Remise (%)</label>
+            <input
+              id="discount"
+              type="number"
+              min="0"
+              max="100"
+              step="0.5"
+              value="0"
+              class="h-9 w-20 rounded-lg border border-transparent bg-white px-2 text-right text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+            />
+          </div>
+          <button
+            id="generate-pdf"
+            class="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          >
+            Générer le devis PDF
+          </button>
+        </div>
       </div>
     </nav>
     <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
@@ -36,7 +53,7 @@
                 Parcourez le catalogue et ajoutez les articles souhaités directement à votre devis.
               </p>
             </div>
-            <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
               <div class="relative w-full lg:max-w-md">
                 <label for="search" class="sr-only">Rechercher un produit</label>
                 <input
@@ -79,6 +96,15 @@
                   </div>
                 </div>
               </div>
+              <div class="relative xl:w-52">
+                <label for="unit-filter" class="sr-only">Filtrer par unité</label>
+                <select
+                  id="unit-filter"
+                  class="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition hover:border-blue-300 hover:bg-white focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                >
+                  <option value="">Toutes les unités</option>
+                </select>
+              </div>
             </div>
           </header>
           <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
@@ -91,6 +117,34 @@
               <p class="text-sm text-slate-500">Ajustez les quantités et vérifiez les totaux en temps réel.</p>
             </div>
           </header>
+          <section class="quote-summary-panel mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <dl class="space-y-2 text-sm text-slate-600">
+              <div class="flex items-center justify-between">
+                <dt>Total HT</dt>
+                <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between gap-3">
+                <dt class="flex-1">Remise (%)</dt>
+                <dd id="summary-discount-rate" class="font-semibold text-slate-900">0,00 %</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Montant remise</dt>
+                <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Base HT après remise</dt>
+                <dd id="summary-net" class="text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>TVA (20%)</dt>
+                <dd id="summary-vat" class="text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between text-base font-semibold text-slate-900">
+                <dt>Total TTC</dt>
+                <dd id="summary-total">0,00 €</dd>
+              </div>
+            </dl>
+          </section>
           <div id="quote-empty" class="mt-4 flex flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-10 w-10 text-slate-300" fill="none" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
@@ -99,41 +153,9 @@
             <p>Aucun article n'a encore été ajouté. Utilisez le bouton « Ajouter au devis » sur un produit.</p>
           </div>
           <div id="quote-list" class="mt-4 hidden flex-1 space-y-4 overflow-y-auto pr-1"></div>
-          <div class="mt-6 space-y-4">
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
-              <label for="general-comment" class="text-sm font-medium text-slate-700">Commentaire général</label>
-              <textarea id="general-comment" class="general-comment mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez un message qui apparaîtra sur le devis généré..."></textarea>
-            </div>
-            <footer class="border-t border-slate-200 pt-4">
-              <dl class="space-y-2 text-sm text-slate-600">
-                <div class="flex items-center justify-between">
-                  <dt>Total HT</dt>
-                  <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between gap-3">
-                  <dt class="flex-1">Remise (%)</dt>
-                  <dd class="flex items-center gap-2">
-                    <input id="discount" type="number" min="0" max="100" step="0.5" value="0" class="h-9 w-20 rounded-lg border border-slate-200 bg-white px-2 text-right text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" />
-                  </dd>
-                </div>
-                <div class="flex items-center justify-between">
-                  <dt>Montant remise</dt>
-                  <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between">
-                  <dt>Base HT après remise</dt>
-                  <dd id="summary-net" class="text-slate-900">0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between">
-                  <dt>TVA (20%)</dt>
-                  <dd id="summary-vat" class="text-slate-900">0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between text-base font-semibold text-slate-900">
-                  <dt>Total TTC</dt>
-                  <dd id="summary-total">0,00 €</dd>
-                </div>
-              </dl>
-            </footer>
+          <div class="mt-6 rounded-xl border border-slate-200 bg-slate-50 p-4">
+            <label for="general-comment" class="text-sm font-medium text-slate-700">Commentaire général</label>
+            <textarea id="general-comment" class="general-comment mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez un message qui apparaîtra sur le devis généré..."></textarea>
           </div>
         </aside>
       </div>
@@ -148,21 +170,17 @@
           </div>
         </div>
         <div class="mt-4 flex flex-1 flex-col gap-4">
-          <div class="flex flex-1 gap-4">
-            <div class="product-thumbnail">
-              <img class="product-thumbnail-image" alt="" />
+          <div class="flex-1">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="product-category-badge"></span>
             </div>
-            <div class="flex-1">
-              <div class="flex flex-wrap items-center gap-2">
-                <span class="product-category-badge"></span>
-              </div>
-              <h3 class="product-name mt-2 text-base font-semibold text-slate-900"></h3>
-              <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
-            </div>
+            <h3 class="product-name mt-3 text-base font-semibold text-slate-900"></h3>
+            <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
           </div>
           <div class="product-actions">
-            <div>
-              <p class="product-price text-lg font-semibold text-blue-600"></p>
+            <div class="product-prices">
+              <p class="product-price-original"></p>
+              <p class="product-price-current text-lg font-semibold text-blue-600"></p>
               <p class="product-unit text-xs text-slate-400"></p>
             </div>
             <div class="flex flex-col items-end gap-2">
@@ -188,7 +206,10 @@
               <span class="quote-reference"></span>
             </span>
             <span class="summary-quantity" data-role="summary-quantity"></span>
-            <span class="summary-total" data-role="summary-total"></span>
+            <span class="summary-total" data-role="summary-total">
+              <span class="price-original summary-total-original"></span>
+              <span class="price-current summary-total-current"></span>
+            </span>
           </button>
           <button class="remove-item" type="button">Retirer</button>
         </div>
@@ -227,11 +248,17 @@
             <div class="price-column">
               <div>
                 <span class="price-label">PU HT</span>
-                <span class="unit-price"></span>
+                <div class="price-values">
+                  <span class="price-original unit-price-original"></span>
+                  <span class="price-current unit-price"></span>
+                </div>
               </div>
               <div>
                 <span class="price-label">Total ligne</span>
-                <span class="line-total"></span>
+                <div class="price-values">
+                  <span class="price-original line-total-original"></span>
+                  <span class="price-current line-total"></span>
+                </div>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Résumé
- déplacer le champ de remise modifiable dans l’en-tête et afficher un récapitulatif statique au-dessus du devis en cours
- afficher les prix barrés/actualisés sur les tuiles produits et les lignes du devis en fonction de la remise globale
- ajouter un filtre par unité ainsi que des ajustements responsive pour améliorer la consultation mobile

## Tests
- Aucun test automatisé disponible pour ce projet statique

------
https://chatgpt.com/codex/tasks/task_b_68e284e52f5c8329a2cfecf696e839aa