### PR TITLE
Réorganise l'interface du devis et la gestion des remises

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -16,6 +16,7 @@
 
 .main-layout {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
 }
 
@@ -89,23 +90,6 @@
   backdrop-filter: blur(4px);
 }
 
-.product-thumbnail {
-  position: relative;
-  flex-shrink: 0;
-  width: 4.5rem;
-  height: 4.5rem;
-  border-radius: 1rem;
-  overflow: hidden;
-  background: #e2e8f0;
-  box-shadow: inset 0 1px 1px rgba(148, 163, 184, 0.4);
-}
-
-.product-thumbnail-image {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
 .product-category-badge {
   display: inline-flex;
   align-items: center;
@@ -130,6 +114,39 @@
   align-items: center;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.product-price-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.product-price-wrapper {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+.product-price-wrapper .product-price-original {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  text-decoration: line-through;
+}
+
+.product-price-wrapper .product-price-discount {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.product-price-wrapper:not(.is-discounted) .product-price-original {
+  display: none;
+}
+
+.product-price-wrapper:not(.is-discounted) .product-price-discount {
+  color: #0f172a;
 }
 
 .category-filter-menu {
@@ -365,20 +382,24 @@
   color: #94a3b8;
 }
 
-.summary-quantity,
-.summary-total {
+.summary-quantity {
+  margin-left: auto;
   font-size: 0.75rem;
   font-weight: 600;
   color: #0f172a;
 }
 
-.summary-quantity {
-  margin-left: auto;
+.summary-total {
+  margin-left: 0.5rem;
+  align-items: flex-end;
 }
 
-.summary-total {
-  color: #1d4ed8;
-  margin-left: 0.5rem;
+.summary-total .price-discount {
+  font-size: 0.85rem;
+}
+
+.summary-total .price-original {
+  font-size: 0.7rem;
 }
 
 .quote-details {
@@ -519,9 +540,30 @@
   color: #94a3b8;
 }
 
-.line-total {
+.price-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+}
+
+.price-stack .price-original {
+  font-size: 0.85rem;
+  color: #94a3b8;
+  text-decoration: line-through;
+}
+
+.price-stack .price-discount {
   font-weight: 700;
   color: #1d4ed8;
+}
+
+.price-stack:not(.is-discounted) .price-original {
+  display: none;
+}
+
+.price-stack:not(.is-discounted) .price-discount {
+  color: #0f172a;
 }
 
 .quote-comment-block {
@@ -568,6 +610,24 @@
   gap: 1.5rem;
 }
 
+.site-footer--panel {
+  margin: -1.5rem -1.5rem 1.5rem;
+  border-radius: 1.25rem;
+  flex-shrink: 0;
+}
+
+.site-footer--panel .footer-inner {
+  max-width: 100%;
+  padding: 2rem 1.5rem;
+}
+
+.quote-panel-body {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
 .footer-meta {
   display: flex;
   flex-wrap: wrap;
@@ -594,5 +654,68 @@
 
   .gutter.gutter-horizontal {
     display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .nav-inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .nav-inner > div:first-child {
+    width: 100%;
+  }
+
+  .nav-inner > div:last-child {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  #discount-control {
+    width: 100%;
+  }
+
+  #generate-pdf {
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  body {
+    font-size: 0.95rem;
+  }
+
+  #catalogue-panel,
+  #quote-panel {
+    padding: 1.25rem;
+  }
+
+  .product-card {
+    padding: 1.25rem;
+  }
+
+  .product-actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .product-actions .flex {
+    width: 100%;
+  }
+
+  .price-column {
+    width: 100%;
+  }
+
+  .site-footer--panel {
+    margin: -1rem -1rem 1rem;
+  }
+
+  .site-footer--panel .footer-inner {
+    padding: 1.5rem 1rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   </head>
   <body class="bg-slate-100 text-slate-800 min-h-screen">
     <nav class="fixed inset-x-0 top-0 z-40 bg-white shadow-sm">
-      <div class="mx-auto flex w-full max-w-[120rem] items-center justify-between px-4 py-4">
+      <div class="nav-inner mx-auto flex w-full max-w-[120rem] flex-wrap items-center justify-between gap-4 px-4 py-4">
         <div class="flex items-center gap-3">
           <div class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-white font-semibold">DV</div>
           <div>
@@ -21,9 +21,26 @@
             <p class="text-sm text-slate-500">Créez vos devis en quelques clics</p>
           </div>
         </div>
-        <button id="generate-pdf" class="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
-          Générer le devis PDF
-        </button>
+        <div class="flex flex-wrap items-center gap-4">
+          <div class="flex flex-col gap-1 text-sm text-slate-600">
+            <label for="discount-control" class="font-semibold text-slate-700">Remise (%)</label>
+            <input
+              id="discount-control"
+              type="number"
+              min="0"
+              max="100"
+              step="0.5"
+              value="0"
+              class="h-10 w-28 rounded-lg border border-slate-200 bg-white px-3 text-right text-sm font-semibold text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+            />
+          </div>
+          <button
+            id="generate-pdf"
+            class="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+          >
+            Générer le devis PDF
+          </button>
+        </div>
       </div>
     </nav>
     <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
@@ -79,61 +96,104 @@
                   </div>
                 </div>
               </div>
+              <div class="relative lg:w-56">
+                <label for="unit-filter" class="sr-only">Filtrer par unité</label>
+                <select
+                  id="unit-filter"
+                  class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-4 pr-10 text-sm text-slate-700 shadow-inner transition focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                >
+                  <option value="">Toutes les unités</option>
+                </select>
+                <svg class="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.5 8.25 12 15.75 4.5 8.25" />
+                </svg>
+              </div>
             </div>
           </header>
           <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
           <div id="product-grid" class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>
         </section>
         <aside id="quote-panel" class="split-panel rounded-2xl bg-white p-6 shadow-lg">
-          <header class="flex items-start justify-between gap-2">
-            <div>
-              <h2 class="text-xl font-semibold text-slate-900">Devis en cours</h2>
-              <p class="text-sm text-slate-500">Ajustez les quantités et vérifiez les totaux en temps réel.</p>
+          <footer class="site-footer site-footer--panel">
+            <div class="footer-inner">
+              <div>
+                <p class="text-lg font-semibold text-white">Deviseur Express</p>
+                <p class="mt-1 text-sm text-slate-300">Accélérez la création de vos devis et partagez-les en un instant.</p>
+              </div>
+              <div class="footer-meta">
+                <span>
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0-9-9 9 9 0 0 0 9 9Z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9 12 12.75 9.75 10.5" />
+                  </svg>
+                  Lundi - Vendredi : 9h - 18h
+                </span>
+                <span>
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 7.5 12 12.75 2.25 7.5m19.5 0v9a2.25 2.25 0 0 1-2.25 2.25h-15A2.25 2.25 0 0 1 2.25 16.5v-9a2.25 2.25 0 0 1 2.25-2.25h15A2.25 2.25 0 0 1 21.75 7.5Z" />
+                  </svg>
+                  contact@deviseurexpress.fr
+                </span>
+                <span>
+                  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 4.5h19.5M4.5 4.5h15a2.25 2.25 0 0 1 2.25 2.25v11.25A2.25 2.25 0 0 1 19.5 20.25h-15A2.25 2.25 0 0 1 2.25 18V6.75A2.25 2.25 0 0 1 4.5 4.5Z" />
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z" />
+                  </svg>
+                  12 avenue des Solutions, 75000 Paris
+                </span>
+              </div>
+              <p class="text-xs text-slate-500">© <span id="current-year"></span> Deviseur Express — Tous droits réservés.</p>
             </div>
-          </header>
-          <div id="quote-empty" class="mt-4 flex flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-10 w-10 text-slate-300" fill="none" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5v-12A1.5 1.5 0 0 0 19.5 4.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
-            </svg>
-            <p>Aucun article n'a encore été ajouté. Utilisez le bouton « Ajouter au devis » sur un produit.</p>
-          </div>
-          <div id="quote-list" class="mt-4 hidden flex-1 space-y-4 overflow-y-auto pr-1"></div>
-          <div class="mt-6 space-y-4">
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
-              <label for="general-comment" class="text-sm font-medium text-slate-700">Commentaire général</label>
-              <textarea id="general-comment" class="general-comment mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez un message qui apparaîtra sur le devis généré..."></textarea>
+          </footer>
+          <div class="quote-panel-body flex flex-1 flex-col">
+            <header class="flex items-start justify-between gap-2">
+              <div>
+                <h2 class="text-xl font-semibold text-slate-900">Devis en cours</h2>
+                <p class="text-sm text-slate-500">Ajustez les quantités et vérifiez les totaux en temps réel.</p>
+              </div>
+            </header>
+            <div id="quote-empty" class="flex flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-10 w-10 text-slate-300" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5v-12A1.5 1.5 0 0 0 19.5 4.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
+              </svg>
+              <p>Aucun article n'a encore été ajouté. Utilisez le bouton « Ajouter au devis » sur un produit.</p>
             </div>
-            <footer class="border-t border-slate-200 pt-4">
-              <dl class="space-y-2 text-sm text-slate-600">
-                <div class="flex items-center justify-between">
-                  <dt>Total HT</dt>
-                  <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between gap-3">
-                  <dt class="flex-1">Remise (%)</dt>
-                  <dd class="flex items-center gap-2">
-                    <input id="discount" type="number" min="0" max="100" step="0.5" value="0" class="h-9 w-20 rounded-lg border border-slate-200 bg-white px-2 text-right text-sm focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" />
-                  </dd>
-                </div>
-                <div class="flex items-center justify-between">
-                  <dt>Montant remise</dt>
-                  <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between">
-                  <dt>Base HT après remise</dt>
-                  <dd id="summary-net" class="text-slate-900">0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between">
-                  <dt>TVA (20%)</dt>
-                  <dd id="summary-vat" class="text-slate-900">0,00 €</dd>
-                </div>
-                <div class="flex items-center justify-between text-base font-semibold text-slate-900">
-                  <dt>Total TTC</dt>
-                  <dd id="summary-total">0,00 €</dd>
-                </div>
-              </dl>
-            </footer>
+            <div id="quote-list" class="hidden flex-1 space-y-4 overflow-y-auto pr-1"></div>
+            <div class="space-y-4">
+              <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <label for="general-comment" class="text-sm font-medium text-slate-700">Commentaire général</label>
+                <textarea id="general-comment" class="general-comment mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez un message qui apparaîtra sur le devis généré..."></textarea>
+              </div>
+              <footer class="border-t border-slate-200 pt-4">
+                <dl class="space-y-2 text-sm text-slate-600">
+                  <div class="flex items-center justify-between">
+                    <dt>Total HT</dt>
+                    <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
+                  </div>
+                  <div class="flex items-center justify-between gap-3">
+                    <dt class="flex-1">Remise (%)</dt>
+                    <dd id="summary-discount-rate" class="text-sm font-semibold text-slate-900">0 %</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Montant remise</dt>
+                    <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>Base HT après remise</dt>
+                    <dd id="summary-net" class="text-slate-900">0,00 €</dd>
+                  </div>
+                  <div class="flex items-center justify-between">
+                    <dt>TVA (20%)</dt>
+                    <dd id="summary-vat" class="text-slate-900">0,00 €</dd>
+                  </div>
+                  <div class="flex items-center justify-between text-base font-semibold text-slate-900">
+                    <dt>Total TTC</dt>
+                    <dd id="summary-total">0,00 €</dd>
+                  </div>
+                </dl>
+              </footer>
+            </div>
           </div>
         </aside>
       </div>
@@ -148,21 +208,19 @@
           </div>
         </div>
         <div class="mt-4 flex flex-1 flex-col gap-4">
-          <div class="flex flex-1 gap-4">
-            <div class="product-thumbnail">
-              <img class="product-thumbnail-image" alt="" />
+          <div class="flex flex-1 flex-col">
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="product-category-badge"></span>
             </div>
-            <div class="flex-1">
-              <div class="flex flex-wrap items-center gap-2">
-                <span class="product-category-badge"></span>
-              </div>
-              <h3 class="product-name mt-2 text-base font-semibold text-slate-900"></h3>
-              <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
-            </div>
+            <h3 class="product-name mt-3 text-base font-semibold text-slate-900"></h3>
+            <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
           </div>
           <div class="product-actions">
-            <div>
-              <p class="product-price text-lg font-semibold text-blue-600"></p>
+            <div class="product-price-block">
+              <div class="product-price-wrapper">
+                <span class="product-price-original"></span>
+                <span class="product-price-discount"></span>
+              </div>
               <p class="product-unit text-xs text-slate-400"></p>
             </div>
             <div class="flex flex-col items-end gap-2">
@@ -188,7 +246,10 @@
               <span class="quote-reference"></span>
             </span>
             <span class="summary-quantity" data-role="summary-quantity"></span>
-            <span class="summary-total" data-role="summary-total"></span>
+            <span class="summary-total price-stack" data-role="summary-total">
+              <span class="price-original" data-role="summary-total-original"></span>
+              <span class="price-discount" data-role="summary-total-discount"></span>
+            </span>
           </button>
           <button class="remove-item" type="button">Retirer</button>
         </div>
@@ -227,11 +288,17 @@
             <div class="price-column">
               <div>
                 <span class="price-label">PU HT</span>
-                <span class="unit-price"></span>
+                <div class="price-stack">
+                  <span class="price-original" data-role="unit-price-original"></span>
+                  <span class="price-discount" data-role="unit-price-discount"></span>
+                </div>
               </div>
               <div>
                 <span class="price-label">Total ligne</span>
-                <span class="line-total"></span>
+                <div class="price-stack">
+                  <span class="price-original" data-role="line-total-original"></span>
+                  <span class="price-discount" data-role="line-total-discount"></span>
+                </div>
               </div>
             </div>
           </div>
@@ -260,36 +327,5 @@
       </div>
     </div>
 
-    <footer class="site-footer">
-      <div class="footer-inner">
-        <div>
-          <p class="text-lg font-semibold text-white">Deviseur Express</p>
-          <p class="mt-1 text-sm text-slate-300">Accélérez la création de vos devis et partagez-les en un instant.</p>
-        </div>
-        <div class="footer-meta">
-          <span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9 9 0 1 0-9-9 9 9 0 0 0 9 9Z" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9 12 12.75 9.75 10.5" />
-            </svg>
-            Lundi - Vendredi : 9h - 18h
-          </span>
-          <span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 7.5 12 12.75 2.25 7.5m19.5 0v9a2.25 2.25 0 0 1-2.25 2.25h-15A2.25 2.25 0 0 1 2.25 16.5v-9a2.25 2.25 0 0 1 2.25-2.25h15A2.25 2.25 0 0 1 21.75 7.5Z" />
-            </svg>
-            contact@deviseurexpress.fr
-          </span>
-          <span>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 4.5h19.5M4.5 4.5h15a2.25 2.25 0 0 1 2.25 2.25v11.25A2.25 2.25 0 0 1 19.5 20.25h-15A2.25 2.25 0 0 1 2.25 18V6.75A2.25 2.25 0 0 1 4.5 4.5Z" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Z" />
-            </svg>
-            12 avenue des Solutions, 75000 Paris
-          </span>
-        </div>
-        <p class="text-xs text-slate-500">© <span id="current-year"></span> Deviseur Express — Tous droits réservés.</p>
-      </div>
-    </footer>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- Déplace la saisie de remise dans la barre supérieure et fige l’affichage du taux dans le récapitulatif
- Affiche les prix barrés et remisés sur les cartes produit ainsi que dans les lignes de devis
- Ajoute un filtre par unité, un pied de page intégré au panneau devis et des ajustements responsive mobile

## Testing
- Not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e284e52f5c8329a2cfecf696e839aa