### PR TITLE
Adapte le catalogue au nouvel export avec écotaxe

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -108,6 +108,61 @@
   color: #64748b;
 }
 
+.product-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  align-items: center;
+}
+
+.score-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.55rem;
+  border-radius: 9999px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(148, 163, 184, 0.2);
+  color: #475569;
+}
+
+.score-badge.is-excellent {
+  background: rgba(34, 197, 94, 0.18);
+  color: #047857;
+}
+
+.score-badge.is-good {
+  background: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.score-badge.is-average {
+  background: rgba(251, 191, 36, 0.22);
+  color: #b45309;
+}
+
+.score-badge.is-weak {
+  background: rgba(248, 113, 113, 0.22);
+  color: #b91c1c;
+}
+
+.score-badge.is-poor {
+  background: rgba(239, 68, 68, 0.25);
+  color: #991b1b;
+}
+
+.score-badge.is-unknown {
+  background: rgba(148, 163, 184, 0.15);
+  color: #64748b;
+}
+
+.product-ecotax {
+  color: #475569;
+}
+
 .product-card .product-actions {
   display: flex;
   align-items: flex-end;
@@ -257,6 +312,27 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.modal-meta {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: #475569;
+}
+
+.modal-meta li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.modal-meta .score-badge {
+  font-size: 0.7rem;
 }
 
 .modal-actions {
@@ -410,6 +486,16 @@
   display: flex;
 }
 
+.quote-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.quote-meta .score-badge {
+  font-size: 0.6rem;
+}
+
 .quote-body {
   display: flex;
   flex-wrap: wrap;
@@ -535,6 +621,11 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 0.15rem;
+}
+
+.line-ecotax {
+  font-weight: 600;
+  color: #0f172a;
 }
 
 .unit-price-original,

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
           <footer class="quote-summary-panel border-b border-slate-200 pb-4">
             <dl class="space-y-2 text-sm text-slate-600">
               <div class="flex items-center justify-between">
-                <dt>Total HT</dt>
+                <dt>Total articles HT</dt>
                 <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between gap-3">
@@ -124,7 +124,11 @@
                 <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
-                <dt>Base HT après remise</dt>
+                <dt>Écotaxe</dt>
+                <dd id="summary-ecotax" class="text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Base HT après remise + écotaxe</dt>
                 <dd id="summary-net" class="text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
@@ -176,12 +180,17 @@
             </div>
             <h3 class="product-name mt-2 text-base font-semibold text-slate-900"></h3>
             <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
+            <div class="product-meta mt-3 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+              <span class="product-score-badge score-badge"></span>
+              <span class="product-weight"></span>
+            </div>
           </div>
           <div class="product-actions">
             <div class="product-price-block">
               <p class="product-price-original"></p>
               <p class="product-price-discounted"></p>
               <p class="product-unit text-xs text-slate-400"></p>
+              <p class="product-ecotax text-xs text-slate-500"></p>
             </div>
             <div class="flex flex-col items-end gap-2">
               <button class="view-details rounded-lg border border-transparent bg-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
@@ -218,6 +227,9 @@
             <p class="quote-unit text-xs text-slate-500">
               Unité de vente : <span data-role="quantity-unit"></span>
             </p>
+            <span class="quote-score score-badge"></span>
+            <p class="quote-weight text-xs text-slate-500"></p>
+            <p class="quote-ecotax text-xs text-slate-500"></p>
           </div>
           <div class="quote-body">
             <div class="quantity-column">
@@ -254,7 +266,11 @@
                 </span>
               </div>
               <div>
-                <span class="price-label">Total ligne</span>
+                <span class="price-label">Écotaxe</span>
+                <span class="line-ecotax"></span>
+              </div>
+              <div>
+                <span class="price-label">Total ligne HT (avec écotaxe)</span>
                 <span class="line-total">
                   <span class="line-total-original"></span>
                   <span class="line-total-discounted"></span>
@@ -279,6 +295,11 @@
             <h3 id="product-modal-title" class="text-xl font-semibold text-slate-900"></h3>
           </div>
           <p id="product-modal-description" class="text-sm leading-relaxed text-slate-600"></p>
+          <ul class="modal-meta" aria-label="Informations complémentaires sur le produit">
+            <li id="product-modal-score"></li>
+            <li id="product-modal-weight"></li>
+            <li id="product-modal-ecotax"></li>
+          </ul>
           <div class="modal-actions">
             <a id="product-modal-link" class="hidden rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700" target="_blank" rel="noopener">Consulter la fiche</a>
             <button id="product-modal-close" class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">Fermer</button>


### PR DESCRIPTION
## Résumé
- charge le nouveau fichier `export.csv` et normalise les colonnes pour récupérer référence, unité, poids, écotaxe et score positv'ID.
- affiche l'écotaxe, le poids et le score sur les cartes produit, la modale et les lignes du devis avec un style dédié.
- ajoute l'écotaxe aux totaux, au récapitulatif et au PDF généré afin qu'elle soit soumise à la TVA.

## Tests
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_b_68e3b31ac9448329a689f59545f9e742