### PR TITLE
Support du nouvel export catalogue et calcul de l'écotaxe

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -134,6 +134,88 @@
   color: #1d4ed8;
 }
 
+.product-ecotax {
+  color: #b45309;
+}
+
+.product-weight {
+  color: #64748b;
+}
+
+.score-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background-color: #e2e8f0;
+  color: #475569;
+}
+
+.score-badge::before {
+  content: 'Score';
+  font-weight: 600;
+}
+
+.score-badge[data-score='A'] {
+  background-color: #dcfce7;
+  color: #166534;
+}
+
+.score-badge[data-score='B'] {
+  background-color: #f0fdf4;
+  color: #15803d;
+}
+
+.score-badge[data-score='C'] {
+  background-color: #fef3c7;
+  color: #b45309;
+}
+
+.score-badge[data-score='D'] {
+  background-color: #fee2e2;
+  color: #b91c1c;
+}
+
+.score-badge[data-score='E'] {
+  background-color: #fee2e2;
+  color: #991b1b;
+}
+
+.score-badge[data-score='NR'] {
+  background-color: #e2e8f0;
+  color: #475569;
+}
+
+.quote-ecotax {
+  color: #b45309;
+  font-weight: 600;
+}
+
+.quote-weight {
+  color: #64748b;
+}
+
+.quote-score {
+  display: flex;
+  align-items: center;
+}
+
+.quote-score .score-badge::before {
+  content: '';
+}
+
+.line-ecotax {
+  display: block;
+  font-weight: 600;
+  color: #b45309;
+}
+
 .category-filter-menu {
   position: absolute;
   inset-inline-end: 0;
@@ -530,7 +612,8 @@
 }
 
 .unit-price,
-.line-total {
+.line-total,
+.line-total-with-ecotax {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -563,6 +646,23 @@
   color: #1d4ed8;
 }
 
+.line-total-with-ecotax {
+  font-weight: 700;
+  color: #0f172a;
+  align-items: flex-end;
+}
+
+.line-total-with-ecotax-original {
+  font-size: 0.8rem;
+  color: #94a3b8;
+  text-decoration: line-through;
+  display: none;
+}
+
+.line-total-with-ecotax-discounted {
+  color: #0f172a;
+}
+
 .quote-comment-block {
   display: flex;
   flex-direction: column;
@@ -590,6 +690,35 @@
   outline: 2px solid rgba(37, 99, 235, 0.35);
   outline-offset: 1px;
   border-color: #2563eb;
+}
+
+.modal-meta {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1.25rem;
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.modal-meta-item {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.modal-meta-item dt {
+  font-weight: 600;
+  color: #0f172a;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.modal-meta-item dd {
+  margin: 0;
+}
+
+.modal-meta .score-badge::before {
+  content: '';
 }
 
 .site-footer {

--- a/index.html
+++ b/index.html
@@ -110,8 +110,8 @@
           <footer class="quote-summary-panel border-b border-slate-200 pb-4">
             <dl class="space-y-2 text-sm text-slate-600">
               <div class="flex items-center justify-between">
-                <dt>Total HT</dt>
-                <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
+                <dt>Total HT produits</dt>
+                <dd id="summary-products" class="font-semibold text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between gap-3">
                 <dt class="flex-1">Remise (%)</dt>
@@ -124,7 +124,11 @@
                 <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
-                <dt>Base HT après remise</dt>
+                <dt>Écotaxe totale</dt>
+                <dd id="summary-ecotax" class="text-amber-600">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Base HT après remise + écotaxe</dt>
                 <dd id="summary-net" class="text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
@@ -173,6 +177,7 @@
           <div class="flex flex-1 flex-col">
             <div class="flex flex-wrap items-center gap-2">
               <span class="product-category-badge"></span>
+              <span class="score-badge" data-score="NR"></span>
             </div>
             <h3 class="product-name mt-2 text-base font-semibold text-slate-900"></h3>
             <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
@@ -182,6 +187,8 @@
               <p class="product-price-original"></p>
               <p class="product-price-discounted"></p>
               <p class="product-unit text-xs text-slate-400"></p>
+              <p class="product-ecotax text-xs font-semibold text-amber-600"></p>
+              <p class="product-weight text-xs text-slate-400"></p>
             </div>
             <div class="flex flex-col items-end gap-2">
               <button class="view-details rounded-lg border border-transparent bg-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
@@ -218,6 +225,11 @@
             <p class="quote-unit text-xs text-slate-500">
               Unité de vente : <span data-role="quantity-unit"></span>
             </p>
+            <p class="quote-ecotax text-xs text-amber-600"></p>
+            <p class="quote-weight text-xs text-slate-500"></p>
+            <div class="quote-score">
+              <span class="score-badge" data-score="NR"></span>
+            </div>
           </div>
           <div class="quote-body">
             <div class="quantity-column">
@@ -254,10 +266,21 @@
                 </span>
               </div>
               <div>
-                <span class="price-label">Total ligne</span>
+                <span class="price-label">Écotaxe</span>
+                <span class="line-ecotax"></span>
+              </div>
+              <div>
+                <span class="price-label">Total ligne (hors écotaxe)</span>
                 <span class="line-total">
                   <span class="line-total-original"></span>
                   <span class="line-total-discounted"></span>
+                </span>
+              </div>
+              <div>
+                <span class="price-label">Total ligne + écotaxe</span>
+                <span class="line-total-with-ecotax">
+                  <span class="line-total-with-ecotax-original"></span>
+                  <span class="line-total-with-ecotax-discounted"></span>
                 </span>
               </div>
             </div>
@@ -270,20 +293,40 @@
       </div>
     </template>
 
-    <div id="product-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="product-modal-title">
-      <div class="modal-card">
-        <img id="product-modal-image" alt="" />
-        <div class="modal-body">
-          <div class="flex flex-col gap-1">
-            <p id="product-modal-reference" class="text-xs uppercase tracking-wide text-slate-400"></p>
-            <h3 id="product-modal-title" class="text-xl font-semibold text-slate-900"></h3>
+      <div id="product-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="product-modal-title">
+        <div class="modal-card">
+          <img id="product-modal-image" alt="" />
+          <div class="modal-body">
+            <div class="flex flex-col gap-1">
+              <p id="product-modal-reference" class="text-xs uppercase tracking-wide text-slate-400"></p>
+              <h3 id="product-modal-title" class="text-xl font-semibold text-slate-900"></h3>
+            </div>
+            <p id="product-modal-description" class="text-sm leading-relaxed text-slate-600"></p>
+            <dl class="modal-meta">
+              <div class="modal-meta-item">
+                <dt>Unité de vente</dt>
+                <dd id="product-modal-unit"></dd>
+              </div>
+              <div class="modal-meta-item">
+                <dt>Écotaxe applicable</dt>
+                <dd id="product-modal-ecotax"></dd>
+              </div>
+              <div class="modal-meta-item" data-role="modal-meta-weight">
+                <dt>Poids unitaire</dt>
+                <dd id="product-modal-weight"></dd>
+              </div>
+              <div class="modal-meta-item">
+                <dt>Score Positiv'ID</dt>
+                <dd>
+                  <span id="product-modal-score" class="score-badge" data-score="NR"></span>
+                </dd>
+              </div>
+            </dl>
+            <div class="modal-actions">
+              <a id="product-modal-link" class="hidden rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700" target="_blank" rel="noopener">Consulter la fiche</a>
+              <button id="product-modal-close" class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">Fermer</button>
+            </div>
           </div>
-          <p id="product-modal-description" class="text-sm leading-relaxed text-slate-600"></p>
-          <div class="modal-actions">
-            <a id="product-modal-link" class="hidden rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700" target="_blank" rel="noopener">Consulter la fiche</a>
-            <button id="product-modal-close" class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">Fermer</button>
-          </div>
-        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Résumé
- lecture du nouveau fichier `catalogue/export.csv` et adaptation du parsing (unité, score, poids, écotaxe)
- affichage de l'écotaxe et du score sur les cartes produits, dans le devis et dans la fiche détaillée
- intégration de l'écotaxe dans les totaux HT/TVA et dans le PDF exporté, avec colonne dédiée

## Tests
- capture manuelle de l'interface (voir pièce jointe)


------
https://chatgpt.com/codex/tasks/task_b_68e3b31ac9448329a689f59545f9e742