### PR TITLE
Intégration du nouveau catalogue et de l'éco-participation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -108,6 +108,76 @@
   color: #64748b;
 }
 
+.product-score-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  border-radius: 9999px;
+  background-color: rgba(148, 163, 184, 0.2);
+  color: #475569;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background-color 150ms ease, color 150ms ease;
+}
+
+.product-score-badge[data-score='a'] {
+  background-color: rgba(16, 185, 129, 0.15);
+  color: #047857;
+}
+
+.product-score-badge[data-score='b'] {
+  background-color: rgba(20, 184, 166, 0.15);
+  color: #0f766e;
+}
+
+.product-score-badge[data-score='c'] {
+  background-color: rgba(251, 191, 36, 0.18);
+  color: #b45309;
+}
+
+.product-score-badge[data-score='d'] {
+  background-color: rgba(249, 115, 22, 0.18);
+  color: #c2410c;
+}
+
+.product-score-badge[data-score='e'] {
+  background-color: rgba(248, 113, 113, 0.18);
+  color: #b91c1c;
+}
+
+.product-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 0.75rem;
+}
+
+.product-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.product-metric-label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.product-metric-value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #334155;
+}
+
+.product-metric-value.product-ecotax {
+  color: #047857;
+}
+
 .product-card .product-actions {
   display: flex;
   align-items: flex-end;
@@ -259,6 +329,36 @@
   gap: 1rem;
 }
 
+.modal-infos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem 1.25rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.modal-infos li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  font-size: 0.9rem;
+  color: #334155;
+}
+
+.modal-infos li span:first-child {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  font-weight: 600;
+}
+
+.modal-infos li span:last-child {
+  font-weight: 600;
+  color: #1e293b;
+}
+
 .modal-actions {
   display: flex;
   justify-content: flex-end;
@@ -408,6 +508,18 @@
 
 .quote-row[data-expanded='true'] .quote-details {
   display: flex;
+}
+
+.quote-ecotax {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.quote-ecotax-unit {
+  display: block;
+  font-size: 0.7rem;
+  color: #94a3b8;
+  margin-top: 0.2rem;
 }
 
 .quote-body {

--- a/index.html
+++ b/index.html
@@ -110,11 +110,11 @@
           <footer class="quote-summary-panel border-b border-slate-200 pb-4">
             <dl class="space-y-2 text-sm text-slate-600">
               <div class="flex items-center justify-between">
-                <dt>Total HT</dt>
+                <dt>Total HT produits</dt>
                 <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between gap-3">
-                <dt class="flex-1">Remise (%)</dt>
+                <dt class="flex-1">Remise produits (%)</dt>
                 <dd class="flex items-center gap-2">
                   <input id="discount" type="text" value="0" readonly class="h-9 w-20 cursor-not-allowed rounded-lg border border-slate-200 bg-slate-100 px-2 text-right text-sm text-slate-500" />
                 </dd>
@@ -124,7 +124,15 @@
                 <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
-                <dt>Base HT après remise</dt>
+                <dt>Total HT après remise</dt>
+                <dd id="summary-net-products" class="text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Éco-participation</dt>
+                <dd id="summary-ecotax" class="text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Base HT à facturer</dt>
                 <dd id="summary-net" class="text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
@@ -173,9 +181,20 @@
           <div class="flex flex-1 flex-col">
             <div class="flex flex-wrap items-center gap-2">
               <span class="product-category-badge"></span>
+              <span class="product-score-badge" data-score="none">Indice Positiv'ID : Non noté</span>
             </div>
             <h3 class="product-name mt-2 text-base font-semibold text-slate-900"></h3>
             <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
+            <div class="product-metrics mt-3">
+              <div class="product-metric">
+                <span class="product-metric-label">Poids unitaire</span>
+                <span class="product-metric-value product-weight">—</span>
+              </div>
+              <div class="product-metric">
+                <span class="product-metric-label">Éco-participation</span>
+                <span class="product-metric-value product-ecotax">—</span>
+              </div>
+            </div>
           </div>
           <div class="product-actions">
             <div class="product-price-block">
@@ -260,6 +279,11 @@
                   <span class="line-total-discounted"></span>
                 </span>
               </div>
+              <div>
+                <span class="price-label">Éco-participation</span>
+                <span class="quote-ecotax text-sm font-medium text-emerald-600"></span>
+                <span class="quote-ecotax-unit"></span>
+              </div>
             </div>
           </div>
           <div class="quote-comment-block">
@@ -279,6 +303,13 @@
             <h3 id="product-modal-title" class="text-xl font-semibold text-slate-900"></h3>
           </div>
           <p id="product-modal-description" class="text-sm leading-relaxed text-slate-600"></p>
+          <ul class="modal-infos">
+            <li><span>Catégorie</span><span id="product-modal-category">—</span></li>
+            <li><span>Unité de vente</span><span id="product-modal-unit">—</span></li>
+            <li><span>Poids unitaire</span><span id="product-modal-weight">—</span></li>
+            <li><span>Éco-participation</span><span id="product-modal-ecotax">—</span></li>
+            <li><span>Indice Positiv'ID</span><span id="product-modal-score">Non noté</span></li>
+          </ul>
           <div class="modal-actions">
             <a id="product-modal-link" class="hidden rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700" target="_blank" rel="noopener">Consulter la fiche</a>
             <button id="product-modal-close" class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">Fermer</button>


### PR DESCRIPTION
## Résumé
- Charger le nouveau fichier `catalogue/export.csv` et normaliser les données (unité, écotaxe, poids, score) pour constituer le catalogue exploitable dans l’application.
- Enrichir l’interface (cartes produit, détail modal, styles) avec le poids unitaire, l’éco-participation et l’indice Positiv'ID.
- Intégrer l’éco-participation aux lignes de devis, au récapitulatif (HT/TVA/TTC) et au PDF exporté afin qu’elle soit comptabilisée et affichée clairement.

## Tests
- Aucun test automatisé disponible


------
https://chatgpt.com/codex/tasks/task_b_68e3b31ac9448329a689f59545f9e742