### PR TITLE
Intégration du nouvel export catalogue et prise en charge de l'écotaxe

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -108,6 +108,58 @@
   color: #64748b;
 }
 
+.product-score-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 9999px;
+  background-color: rgba(148, 163, 184, 0.18);
+  color: #475569;
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.product-score-badge::before {
+  content: 'Score';
+  font-size: 0.6rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.product-score-badge[data-score='A'] {
+  background-color: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.product-score-badge[data-score='B'] {
+  background-color: rgba(59, 130, 246, 0.18);
+  color: #1d4ed8;
+}
+
+.product-score-badge[data-score='C'] {
+  background-color: rgba(234, 179, 8, 0.18);
+  color: #b45309;
+}
+
+.product-score-badge[data-score='D'] {
+  background-color: rgba(249, 115, 22, 0.18);
+  color: #c2410c;
+}
+
+.product-score-badge[data-score='E'] {
+  background-color: rgba(248, 113, 113, 0.25);
+  color: #b91c1c;
+}
+
+.product-score-badge.is-empty {
+  opacity: 0.7;
+  background-color: rgba(148, 163, 184, 0.15);
+  color: #64748b;
+}
+
 .product-card .product-actions {
   display: flex;
   align-items: flex-end;
@@ -132,6 +184,22 @@
   font-size: 1.125rem;
   font-weight: 600;
   color: #1d4ed8;
+}
+
+.product-base-price {
+  font-size: 0.85rem;
+  color: #475569;
+  font-weight: 500;
+}
+
+.product-ecotax {
+  margin-top: 0.25rem;
+  color: #0f172a;
+  font-weight: 500;
+}
+
+.product-weight {
+  margin-top: 0.5rem;
 }
 
 .category-filter-menu {
@@ -257,6 +325,24 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+}
+
+.modal-highlights {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.modal-highlights span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 9999px;
+  background-color: rgba(148, 163, 184, 0.15);
+  color: #475569;
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
 .modal-actions {
@@ -537,6 +623,24 @@
   gap: 0.15rem;
 }
 
+.ecotax-price {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.85rem;
+  color: #0f172a;
+}
+
+.ecotax-unit {
+  font-size: 0.8rem;
+  color: #64748b;
+}
+
+.ecotax-total {
+  font-weight: 600;
+  color: #0f172a;
+}
+
 .unit-price-original,
 .line-total-original {
   font-size: 0.8rem;
@@ -624,6 +728,12 @@
 .footer-meta svg {
   width: 1rem;
   height: 1rem;
+}
+
+.footer-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .quote-summary-panel {

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
           <footer class="quote-summary-panel border-b border-slate-200 pb-4">
             <dl class="space-y-2 text-sm text-slate-600">
               <div class="flex items-center justify-between">
-                <dt>Total HT</dt>
+                <dt>Total HT produits</dt>
                 <dd id="summary-subtotal" class="font-semibold text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between gap-3">
@@ -124,7 +124,15 @@
                 <dd id="summary-discount" class="text-slate-900">-0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
-                <dt>Base HT après remise</dt>
+                <dt>Base HT après remise (hors écotaxe)</dt>
+                <dd id="summary-net-products" class="text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Écotaxe totale</dt>
+                <dd id="summary-ecotax" class="text-slate-900">0,00 €</dd>
+              </div>
+              <div class="flex items-center justify-between">
+                <dt>Base HT après remise + écotaxe</dt>
                 <dd id="summary-net" class="text-slate-900">0,00 €</dd>
               </div>
               <div class="flex items-center justify-between">
@@ -171,18 +179,22 @@
         </div>
         <div class="mt-4 flex flex-1 flex-col gap-4">
           <div class="flex flex-1 flex-col">
-            <div class="flex flex-wrap items-center gap-2">
-              <span class="product-category-badge"></span>
-            </div>
-            <h3 class="product-name mt-2 text-base font-semibold text-slate-900"></h3>
-            <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="product-category-badge"></span>
+            <span class="product-score-badge"></span>
           </div>
-          <div class="product-actions">
-            <div class="product-price-block">
-              <p class="product-price-original"></p>
-              <p class="product-price-discounted"></p>
-              <p class="product-unit text-xs text-slate-400"></p>
-            </div>
+          <h3 class="product-name mt-2 text-base font-semibold text-slate-900"></h3>
+          <p class="product-description mt-2 line-clamp-3 text-sm text-slate-500"></p>
+          <p class="product-weight text-xs text-slate-500"></p>
+        </div>
+        <div class="product-actions">
+          <div class="product-price-block">
+            <p class="product-price-original"></p>
+            <p class="product-price-discounted"></p>
+            <p class="product-base-price"></p>
+            <p class="product-ecotax text-xs text-slate-500"></p>
+            <p class="product-unit text-xs text-slate-400"></p>
+          </div>
             <div class="flex flex-col items-end gap-2">
               <button class="view-details rounded-lg border border-transparent bg-slate-200 px-3 py-2 text-xs font-semibold text-slate-700 transition hover:bg-slate-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
                 Voir les détails
@@ -247,14 +259,21 @@
             </div>
             <div class="price-column">
               <div>
-                <span class="price-label">PU HT</span>
+                <span class="price-label">PU HT (hors écotaxe)</span>
                 <span class="unit-price">
                   <span class="unit-price-original"></span>
                   <span class="unit-price-discounted"></span>
                 </span>
               </div>
               <div>
-                <span class="price-label">Total ligne</span>
+                <span class="price-label">Écotaxe</span>
+                <span class="ecotax-price">
+                  <span class="ecotax-unit"></span>
+                  <span class="ecotax-total"></span>
+                </span>
+              </div>
+              <div>
+                <span class="price-label">Total ligne HT (écotaxe incluse)</span>
                 <span class="line-total">
                   <span class="line-total-original"></span>
                   <span class="line-total-discounted"></span>
@@ -279,6 +298,12 @@
             <h3 id="product-modal-title" class="text-xl font-semibold text-slate-900"></h3>
           </div>
           <p id="product-modal-description" class="text-sm leading-relaxed text-slate-600"></p>
+          <div id="product-modal-highlights" class="modal-highlights">
+            <span id="product-modal-unit" class="hidden"></span>
+            <span id="product-modal-weight" class="hidden"></span>
+            <span id="product-modal-ecotax" class="hidden"></span>
+            <span id="product-modal-score" class="hidden"></span>
+          </div>
           <div class="modal-actions">
             <a id="product-modal-link" class="hidden rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-blue-700" target="_blank" rel="noopener">Consulter la fiche</a>
             <button id="product-modal-close" class="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:bg-slate-100">Fermer</button>
@@ -315,7 +340,10 @@
             12 avenue des Solutions, 75000 Paris
           </span>
         </div>
-        <p class="text-xs text-slate-500">© <span id="current-year"></span> Deviseur Express — Tous droits réservés.</p>
+        <div class="footer-summary">
+          <p class="text-xs text-slate-400">Écotaxe totale incluse : <span id="footer-ecotax">0,00 €</span></p>
+          <p class="text-xs text-slate-500">© <span id="current-year"></span> Deviseur Express — Tous droits réservés.</p>
+        </div>
       </div>
     </footer>
   </body>


### PR DESCRIPTION
## Résumé
- lecture du nouveau fichier `catalogue/export.csv` et adaptation du parsing pour les nouvelles colonnes (référence, poids, score, écotaxe, image, lien)
- enrichissement des cartes produits et du devis avec l’affichage du score positiv'ID, du poids, de l’écotaxe unitaire et du prix écotaxe incluse
- mise à jour des totaux (résumé, pied de page, PDF) pour inclure l’écotaxe, avec un libellé dédié et l’ajout de la valeur dans le pied de page

## Tests
- non exécutés (application front statique)


------
https://chatgpt.com/codex/tasks/task_b_68e3b31ac9448329a689f59545f9e742