### PR TITLE
Ajout de l’identification SIRET et sauvegarde du panier

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -139,10 +139,44 @@ textarea {
   gap: 1rem;
 }
 
+.brand-logo-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: pointer;
+  transition: transform 150ms ease, filter 150ms ease;
+}
+
+.brand-logo-button:hover,
+.brand-logo-button:focus-visible {
+  transform: scale(1.05);
+}
+
+.brand-logo-button:focus-visible {
+  outline: 3px solid rgba(25, 63, 96, 0.25);
+  outline-offset: 4px;
+}
+
 .brand-logo {
   width: 3rem;
   height: 3rem;
   object-fit: contain;
+}
+
+.webhook-mode-indicator {
+  margin-top: 0.2rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.webhook-mode-indicator[data-mode='test'] {
+  color: var(--color-primary);
 }
 
 .brand-title {
@@ -168,13 +202,71 @@ textarea {
   gap: 0.75rem;
 }
 
+.site-nav__tools {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  flex: 1 1 20rem;
+  min-width: 16rem;
+  order: 1;
+}
+
+.site-nav__siret {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.site-nav__siret-label {
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.siret-input-group {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.siret-input {
+  flex: 1 1 auto;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.55rem 0.75rem;
+  font-size: 0.9rem;
+  color: var(--color-muted-strong);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.siret-input:focus {
+  border-color: var(--color-secondary);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.1);
+}
+
+.site-nav__cart-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.site-nav__cart-controls .btn-secondary {
+  flex: 1 1 10rem;
+  min-width: 10rem;
+}
+
 .site-nav__tree {
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
-  min-width: 16rem;
-  flex: 1 1 16rem;
-  width: min(100%, 24rem);
+  min-width: 10rem;
+  flex: 0 0 12rem;
+  max-width: 12rem;
+  order: 4;
 }
 
 .site-nav__tree-label {
@@ -207,6 +299,49 @@ textarea {
   color: var(--color-muted-strong);
 }
 
+.siret-feedback {
+  min-height: 1.5rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  color: var(--color-muted);
+  white-space: pre-line;
+}
+
+.siret-feedback[data-status='loading'] {
+  color: var(--color-secondary);
+}
+
+.siret-feedback[data-status='success'] {
+  color: var(--color-highlight);
+}
+
+.siret-feedback[data-status='error'] {
+  color: var(--color-primary);
+}
+
+.siret-feedback[data-status='warning'] {
+  color: #b7791f;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.catalogue-toolbar {
+  position: sticky;
+  top: 6.25rem;
+  z-index: 15;
+  background: var(--color-surface);
+}
+
 .discount-field {
   display: inline-flex;
   align-items: center;
@@ -220,6 +355,7 @@ textarea {
   letter-spacing: 0.14em;
   font-weight: 600;
   color: var(--color-secondary);
+  order: 2;
 }
 
 .discount-field__input {
@@ -232,6 +368,10 @@ textarea {
   font-size: 0.85rem;
   font-weight: 600;
   text-align: right;
+}
+
+.site-nav__actions .btn-primary {
+  order: 3;
 }
 
 .discount-field__input:focus {
@@ -288,6 +428,14 @@ textarea {
 .btn-secondary:focus-visible {
   outline: 3px solid rgba(25, 63, 96, 0.25);
   outline-offset: 2px;
+}
+
+.btn-primary:disabled,
+.btn-secondary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
 }
 
 .line-clamp-3 {
@@ -1095,6 +1243,20 @@ textarea {
   .site-nav__actions {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .site-nav__tools {
+    width: 100%;
+  }
+
+  .site-nav__cart-controls .btn-secondary {
+    flex: 1 1 100%;
+  }
+
+  .site-nav__tree {
+    flex: 1 1 100%;
+    max-width: none;
+    order: 3;
   }
 
   #main-layout {

--- a/index.html
+++ b/index.html
@@ -21,13 +21,45 @@
     <nav class="site-nav fixed inset-x-0 top-0 z-40">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
-          <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
+          <button
+            id="webhook-toggle"
+            type="button"
+            class="brand-logo-button"
+            aria-live="polite"
+            aria-label="Basculer l'environnement webhook"
+          >
+            <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
+          </button>
           <div>
             <p class="brand-title">ID GROUP Devis</p>
             <p class="brand-subtitle">Créez vos offres sur mesure en un instant</p>
+            <p id="webhook-mode-indicator" class="webhook-mode-indicator">Webhook : Production</p>
           </div>
         </div>
         <div class="site-nav__actions">
+          <div class="site-nav__tools">
+            <form id="siret-form" class="site-nav__siret" novalidate>
+              <label for="siret-input" class="site-nav__siret-label">Identification client (SIRET)</label>
+              <div class="siret-input-group">
+                <input
+                  id="siret-input"
+                  name="siret"
+                  inputmode="numeric"
+                  autocomplete="off"
+                  placeholder="Saisir un numéro SIRET"
+                  class="siret-input"
+                  maxlength="19"
+                />
+                <button id="siret-submit" type="submit" class="btn-secondary">Valider</button>
+              </div>
+              <p id="siret-feedback" class="siret-feedback" aria-live="polite"></p>
+            </form>
+            <div class="site-nav__cart-controls">
+              <button id="save-cart" type="button" class="btn-secondary">Sauvegarder mon panier</button>
+              <button id="restore-cart" type="button" class="btn-secondary">Restaurer mon panier</button>
+              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+            </div>
+          </div>
           <div class="site-nav__tree">
             <label for="catalogue-tree" class="site-nav__tree-label">Arborescence du catalogue</label>
             <select id="catalogue-tree" class="site-nav__tree-select">
@@ -55,7 +87,7 @@
     <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
-          <header class="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
+          <header class="flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface catalogue-toolbar">
             <div>
               <h1 id="catalogue-title" class="text-2xl font-semibold text-slate-900 brand-heading">Catalogue produits</h1>
               <p class="mt-1 text-sm text-slate-500 brand-text-muted">


### PR DESCRIPTION
## Résumé
- ajoute dans la barre de navigation l’identification par numéro SIRET avec envoi vers les webhooks de test/production et mise à jour automatique de la remise
- permet de sauvegarder le panier au format JSON et de le restaurer en important un fichier
- réduit et repositionne le champ d’arborescence, rend la barre de recherche du catalogue flottante et optimise la génération du PDF (compression et logo allégé)

## Tests
- aucune suite de tests automatisés disponible

------
https://chatgpt.com/codex/tasks/task_b_68e4d75fef488329a611fcd7e44ffce6