### PR TITLE
feat: intégrer le tarif webhook et alléger la navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,7 +14,7 @@
   --color-muted: #9297aa;
   --color-muted-strong: #4a5364;
   --color-border: #a5b7c6;
-  --site-nav-height: 6.25rem;
+  --site-nav-height: 4.75rem;
 }
 
 .site-body {
@@ -120,7 +120,18 @@ textarea {
 .site-nav {
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(12px);
-  border-bottom: 4px solid var(--color-primary);
+  border-bottom: 3px solid var(--color-primary);
+  transition: transform 200ms ease, box-shadow 200ms ease;
+}
+
+.site-nav[data-collapsed='true'] {
+  transform: translateY(calc(-100% + 1.8rem));
+  box-shadow: none;
+}
+
+.site-nav[data-collapsed='false'] {
+  transform: translateY(0);
+  box-shadow: 0 14px 40px -28px rgba(25, 63, 96, 0.55);
 }
 
 .site-nav__inner {
@@ -129,20 +140,20 @@ textarea {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
   max-width: 120rem;
-  padding: 1rem 1.5rem;
+  padding: 0.85rem 1.5rem;
 }
 
 .site-nav__branding {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .brand-logo {
-  width: 3rem;
-  height: 3rem;
+  width: 2.75rem;
+  height: 2.75rem;
   object-fit: contain;
   cursor: pointer;
 }
@@ -150,15 +161,9 @@ textarea {
 .brand-title {
   font-family: var(--font-heading);
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 1.15rem;
   color: var(--color-secondary);
-}
-
-.brand-subtitle {
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--color-muted);
-  letter-spacing: 0.02em;
+  white-space: nowrap;
 }
 
 .site-nav__actions {
@@ -168,6 +173,45 @@ textarea {
   align-items: center;
   justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.site-nav__save-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.save-name-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  font-size: 0.65rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.save-name-field input {
+  border: 1px solid rgba(25, 63, 96, 0.2);
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--color-secondary);
+  background: #fff;
+  min-width: 12rem;
+}
+
+.save-name-field input:focus {
+  outline: none;
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
 }
 
 .site-nav__tree {
@@ -313,6 +357,115 @@ textarea {
   white-space: nowrap;
 }
 
+.webhook-panel {
+  position: fixed;
+  top: 6.5rem;
+  right: 1.5rem;
+  width: min(24rem, 92vw);
+  border-radius: 1rem;
+  background: #fff;
+  border: 1px solid rgba(25, 63, 96, 0.1);
+  box-shadow: 0 26px 60px -32px rgba(25, 63, 96, 0.55);
+  overflow: hidden;
+  transition: opacity 200ms ease, transform 200ms ease;
+  opacity: 0;
+  transform: translateY(-12px);
+  pointer-events: none;
+  z-index: 50;
+}
+
+.webhook-panel[data-open='true'] {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.webhook-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: rgba(25, 63, 96, 0.08);
+}
+
+.webhook-panel__title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.webhook-panel__close {
+  border: none;
+  background: transparent;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.webhook-panel__close:hover,
+.webhook-panel__close:focus-visible {
+  color: var(--color-primary);
+  outline: none;
+}
+
+.webhook-panel__content {
+  padding: 1rem 1.25rem 1.15rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  font-size: 0.9rem;
+  color: var(--color-muted-strong);
+}
+
+.webhook-panel__content p {
+  margin: 0;
+  line-height: 1.45;
+}
+
+.webhook-panel__list {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--color-secondary);
+  font-size: 0.85rem;
+}
+
+.client-form-placeholder {
+  max-width: 50rem;
+  margin: 0 auto 2.5rem;
+  padding: 0 1.5rem;
+}
+
+.client-form-placeholder[data-open='false'] {
+  display: none;
+}
+
+.client-form-placeholder__content {
+  border-radius: 1.2rem;
+  background: rgba(228, 30, 40, 0.06);
+  border: 1px dashed rgba(228, 30, 40, 0.35);
+  padding: 1.75rem;
+  text-align: center;
+  color: var(--color-secondary);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.client-form-placeholder__content h2 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.client-form-placeholder__content p {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
 .catalogue-header {
   position: sticky;
   top: calc(var(--site-nav-height) + 1rem);
@@ -345,7 +498,7 @@ textarea {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
+  padding: 0.45rem 0.75rem;
   border-radius: 999px;
   background: var(--color-soft);
   border: 1px solid rgba(25, 63, 96, 0.15);
@@ -356,22 +509,11 @@ textarea {
   color: var(--color-secondary);
 }
 
-.discount-field__input {
-  width: 5rem;
-  padding: 0.35rem 0.5rem;
-  border-radius: 0.75rem;
-  border: 1px solid rgba(25, 63, 96, 0.2);
-  background: #fff;
+.discount-field__value {
+  font-size: 0.95rem;
+  font-weight: 700;
   color: var(--color-secondary);
-  font-size: 0.85rem;
-  font-weight: 600;
-  text-align: right;
-}
-
-.discount-field__input:focus {
-  outline: none;
-  border-color: var(--color-primary);
-  box-shadow: 0 0 0 3px rgba(228, 30, 40, 0.15);
+  letter-spacing: 0.05em;
 }
 
 .btn-primary,
@@ -1231,6 +1373,19 @@ textarea {
     justify-content: flex-start;
   }
 
+  .site-nav__save-group {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .save-name-field {
+    width: 100%;
+  }
+
+  .save-name-field input {
+    width: 100%;
+  }
+
   .site-nav__identity,
   .site-nav__cart-actions,
   .site-nav__tree {
@@ -1258,6 +1413,12 @@ textarea {
 
   .site-nav__actions .btn-primary {
     width: 100%;
+  }
+
+  .site-nav__save-group {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
   }
 
   .site-nav__cart-actions {

--- a/index.html
+++ b/index.html
@@ -18,19 +18,16 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40">
+    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="true">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
-          <div>
-            <p class="brand-title">ID GROUP Devis</p>
-            <p class="brand-subtitle">Créez vos offres sur mesure en un instant</p>
-          </div>
+          <p class="brand-title">ID GROUP Devis</p>
           <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite">Production</span>
         </div>
         <div class="site-nav__actions">
           <form id="siret-form" class="site-nav__identity" autocomplete="off">
-            <label for="siret-input" class="site-nav__identity-label">Identification SIRET</label>
+            <label for="siret-input" class="site-nav__identity-label">SIRET</label>
             <div class="site-nav__identity-controls">
               <input
                 id="siret-input"
@@ -45,23 +42,21 @@
             </div>
             <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
           </form>
-          <div class="site-nav__cart-actions">
-            <button id="save-cart" type="button" class="btn-secondary">Sauvegarder mon panier</button>
-            <button id="restore-cart" type="button" class="btn-secondary">Restaurer un panier</button>
-            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+          <div class="site-nav__save-group">
+            <label for="save-name" class="save-name-field">
+              <span>Nom de la sauvegarde</span>
+              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
+            </label>
+            <div class="site-nav__cart-actions">
+              <button id="save-cart" type="button" class="btn-secondary">Sauvegarder</button>
+              <button id="restore-cart" type="button" class="btn-secondary">Restaurer</button>
+              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+            </div>
           </div>
-          <label for="header-discount" class="discount-field">
-            <span>Remise (%)</span>
-            <input
-              id="header-discount"
-              type="number"
-              min="0"
-              max="100"
-              step="0.5"
-              value="0"
-              class="discount-field__input"
-            />
-          </label>
+          <div class="discount-field" aria-live="polite">
+            <span>Remise client</span>
+            <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
+          </div>
           <button id="generate-pdf" class="btn-primary">
             Générer le devis PDF
           </button>
@@ -362,6 +357,24 @@
             </div>
           </div>
       </div>
+    </div>
+
+    <section id="client-form-placeholder" class="client-form-placeholder" aria-live="polite" data-open="false">
+      <div class="client-form-placeholder__content">
+        <h2>Formulaire client</h2>
+        <p>
+          Le client n'a pas été reconnu. Un formulaire d'inscription sera bientôt disponible pour compléter vos
+          informations.
+        </p>
+      </div>
+    </section>
+
+    <div id="webhook-panel" class="webhook-panel" role="status" aria-live="assertive" data-open="false">
+      <div class="webhook-panel__header">
+        <p class="webhook-panel__title">Informations webhook</p>
+        <button id="webhook-panel-close" type="button" class="webhook-panel__close" aria-label="Fermer">×</button>
+      </div>
+      <div id="webhook-panel-content" class="webhook-panel__content"></div>
     </div>
 
     <footer class="site-footer">


### PR DESCRIPTION
## Résumé
- intégrer le champ Tarif du webhook pour piloter automatiquement la remise et afficher un panneau d'informations
- alléger la navigation haute avec auto-retrait, affichage du taux de remise et champ de nom de sauvegarde
- enrichir la sauvegarde JSON avec un nom utilisateur + date formatée et afficher un formulaire placeholder pour clients non reconnus

## Tests
- non exécutés (application front statique)


------
https://chatgpt.com/codex/tasks/task_b_68e4f2f3d3a48329b2ddcd2a1fe7ba70