### PR TITLE
feat: intégrer la remise webhook et moderniser l'interface

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,7 +14,7 @@
   --color-muted: #9297aa;
   --color-muted-strong: #4a5364;
   --color-border: #a5b7c6;
-  --site-nav-height: 6.25rem;
+  --site-nav-height: 4.5rem;
 }
 
 .site-body {
@@ -121,6 +121,13 @@ textarea {
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(12px);
   border-bottom: 4px solid var(--color-primary);
+  transition: transform 250ms ease, box-shadow 250ms ease;
+  transform: translateY(0);
+}
+
+.site-nav.is-collapsed {
+  transform: translateY(calc(-100% + 3.25rem));
+  box-shadow: none;
 }
 
 .site-nav__inner {
@@ -129,20 +136,20 @@ textarea {
   flex-wrap: wrap;
   align-items: center;
   justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
   max-width: 120rem;
-  padding: 1rem 1.5rem;
+  padding: 0.75rem 1.5rem;
 }
 
 .site-nav__branding {
   display: flex;
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .brand-logo {
-  width: 3rem;
-  height: 3rem;
+  width: 2.75rem;
+  height: 2.75rem;
   object-fit: contain;
   cursor: pointer;
 }
@@ -150,8 +157,9 @@ textarea {
 .brand-title {
   font-family: var(--font-heading);
   font-weight: 700;
-  font-size: 1.25rem;
+  font-size: 1.2rem;
   color: var(--color-secondary);
+  letter-spacing: 0.08em;
 }
 
 .brand-subtitle {
@@ -167,6 +175,14 @@ textarea {
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.site-nav__quick-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 0.75rem;
 }
 
@@ -309,6 +325,36 @@ textarea {
   flex-wrap: wrap;
 }
 
+.save-name-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  min-width: 12rem;
+}
+
+.save-name-field__label {
+  font-size: 0.65rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.save-name-field__input {
+  border-radius: 0.65rem;
+  border: 1px solid rgba(25, 63, 96, 0.18);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.45rem 0.65rem;
+  font-size: 0.85rem;
+  color: var(--color-secondary);
+}
+
+.save-name-field__input:focus {
+  outline: none;
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
+}
+
 .site-nav__cart-actions .btn-secondary {
   white-space: nowrap;
 }
@@ -372,6 +418,13 @@ textarea {
   outline: none;
   border-color: var(--color-primary);
   box-shadow: 0 0 0 3px rgba(228, 30, 40, 0.15);
+}
+
+.discount-field__input[readonly] {
+  background: rgba(236, 239, 244, 0.7);
+  border-color: rgba(25, 63, 96, 0.12);
+  color: var(--color-secondary);
+  cursor: default;
 }
 
 .btn-primary,
@@ -762,6 +815,87 @@ textarea {
   overflow: hidden;
 }
 
+.webhook-panel {
+  position: fixed;
+  inset-inline-end: 2rem;
+  inset-block-end: 2rem;
+  width: min(22rem, 92vw);
+  padding: 1.1rem 1.25rem;
+  border-radius: 1rem;
+  background: #fff;
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  box-shadow: 0 25px 55px -30px rgba(25, 63, 96, 0.55);
+  transform: translateY(1.5rem);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 220ms ease, transform 220ms ease;
+  z-index: 60;
+}
+
+.webhook-panel[data-open='true'] {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.webhook-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.webhook-panel__title {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.webhook-panel__close {
+  border: none;
+  background: rgba(228, 30, 40, 0.1);
+  color: var(--color-primary);
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.webhook-panel__close:hover,
+.webhook-panel__close:focus-visible {
+  background: rgba(228, 30, 40, 0.18);
+  color: var(--color-primary-dark);
+  outline: none;
+}
+
+.webhook-panel__content {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.5rem;
+  max-height: 16rem;
+  overflow-y: auto;
+}
+
+.webhook-panel__content dt {
+  font-size: 0.8rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.webhook-panel__content dd {
+  margin: 0 0 0.35rem;
+  font-size: 0.9rem;
+  color: var(--color-muted-strong);
+  white-space: pre-wrap;
+}
+
 .modal-card img {
   width: 100%;
   height: 16rem;
@@ -789,6 +923,43 @@ textarea {
   border-radius: 1rem;
   background: rgba(255, 255, 255, 0.9);
   padding: 1rem;
+}
+
+.inactive-form {
+  display: none;
+  justify-content: center;
+  padding: 2rem 1rem 3rem;
+}
+
+.inactive-form:not([hidden]) {
+  display: flex;
+}
+
+.inactive-form__card {
+  max-width: 32rem;
+  width: 100%;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  box-shadow: 0 30px 60px -45px rgba(25, 63, 96, 0.55);
+  padding: 2rem;
+  text-align: center;
+}
+
+.inactive-form__card h2 {
+  font-size: 1.25rem;
+  margin-bottom: 0.75rem;
+  color: var(--color-secondary);
+}
+
+.inactive-form__card p {
+  margin-bottom: 0.5rem;
+  color: var(--color-muted-strong);
+}
+
+.inactive-form__hint {
+  font-size: 0.85rem;
+  color: var(--color-muted);
 }
 
 .quote-summary {
@@ -1218,6 +1389,10 @@ textarea {
   .gutter.gutter-horizontal {
     display: none;
   }
+
+  .site-nav.is-collapsed {
+    transform: translateY(0);
+  }
 }
 
 @media (max-width: 768px) {
@@ -1231,12 +1406,23 @@ textarea {
     justify-content: flex-start;
   }
 
+  .site-nav__quick-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
   .site-nav__identity,
   .site-nav__cart-actions,
   .site-nav__tree {
     width: 100%;
     flex: 1 1 100%;
     margin-left: 0;
+  }
+
+  .webhook-panel {
+    inset-inline-end: 1rem;
+    inset-block-end: 1rem;
+    width: calc(100% - 2rem);
   }
 
   #main-layout {
@@ -1256,6 +1442,11 @@ textarea {
     gap: 0.5rem;
   }
 
+  .site-nav__quick-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
   .site-nav__actions .btn-primary {
     width: 100%;
   }
@@ -1267,6 +1458,16 @@ textarea {
 
   .site-nav__cart-actions .btn-secondary {
     width: 100%;
+  }
+
+  .save-name-field {
+    width: 100%;
+  }
+
+  .webhook-panel {
+    inset-inline-end: 0.75rem;
+    inset-inline-start: 0.75rem;
+    width: auto;
   }
 
   .product-card {

--- a/index.html
+++ b/index.html
@@ -22,10 +22,7 @@
       <div class="site-nav__inner">
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
-          <div>
-            <p class="brand-title">ID GROUP Devis</p>
-            <p class="brand-subtitle">Créez vos offres sur mesure en un instant</p>
-          </div>
+          <p class="brand-title" aria-label="ID Group devis">ID GROUP</p>
           <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite">Production</span>
         </div>
         <div class="site-nav__actions">
@@ -45,36 +42,46 @@
             </div>
             <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
           </form>
-          <div class="site-nav__cart-actions">
-            <button id="save-cart" type="button" class="btn-secondary">Sauvegarder mon panier</button>
-            <button id="restore-cart" type="button" class="btn-secondary">Restaurer un panier</button>
-            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-          </div>
-          <label for="header-discount" class="discount-field">
-            <span>Remise (%)</span>
-            <input
-              id="header-discount"
-              type="number"
-              min="0"
-              max="100"
-              step="0.5"
-              value="0"
-              class="discount-field__input"
-            />
-          </label>
-          <button id="generate-pdf" class="btn-primary">
-            Générer le devis PDF
-          </button>
-          <div class="site-nav__tree">
-            <label for="catalogue-tree" class="site-nav__tree-label">Arborescence du catalogue</label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
-              <option value="">Sélectionner une catégorie ou un article</option>
-            </select>
+          <div class="site-nav__quick-actions">
+            <label for="save-name" class="save-name-field">
+              <span class="save-name-field__label">Nom de sauvegarde</span>
+              <input
+                id="save-name"
+                type="text"
+                maxlength="50"
+                placeholder="Nom du fichier"
+                class="save-name-field__input"
+                autocomplete="off"
+              />
+            </label>
+            <div class="site-nav__cart-actions">
+              <button id="save-cart" type="button" class="btn-secondary">Sauvegarder</button>
+              <button id="restore-cart" type="button" class="btn-secondary">Restaurer</button>
+              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+            </div>
+            <label for="header-discount" class="discount-field">
+              <span>Remise client (%)</span>
+              <input
+                id="header-discount"
+                type="text"
+                value="0"
+                class="discount-field__input"
+                readonly
+                aria-readonly="true"
+              />
+            </label>
+            <button id="generate-pdf" class="btn-primary">Générer le devis</button>
+            <div class="site-nav__tree">
+              <label for="catalogue-tree" class="site-nav__tree-label">Catalogue</label>
+              <select id="catalogue-tree" class="site-nav__tree-select">
+                <option value="">Sélectionner une catégorie ou un article</option>
+              </select>
+            </div>
           </div>
         </div>
       </div>
     </nav>
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
+    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-24">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
           <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
@@ -198,6 +205,32 @@
         </aside>
       </div>
     </main>
+
+    <section id="formulaire-inactif" class="inactive-form" hidden>
+      <div class="inactive-form__card">
+        <h2>Formulaire d'accueil client</h2>
+        <p>Ce formulaire sera bientôt disponible pour les clients non reconnus.</p>
+        <p class="inactive-form__hint">Notre équipe vous contactera dès son activation.</p>
+      </div>
+    </section>
+
+    <aside
+      id="webhook-response-panel"
+      class="webhook-panel"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      aria-hidden="true"
+      tabindex="-1"
+    >
+      <div class="webhook-panel__header">
+        <h2 class="webhook-panel__title">Réponse du webhook</h2>
+        <button type="button" class="webhook-panel__close" aria-label="Fermer les informations" data-role="webhook-close">
+          ×
+        </button>
+      </div>
+      <dl id="webhook-response-content" class="webhook-panel__content"></dl>
+    </aside>
 
     <template id="product-card-template">
       <article class="product-card group flex h-full flex-col rounded-2xl bg-white p-5 shadow-sm transition">


### PR DESCRIPTION
## Résumé
- Simplifier la barre supérieure, ajouter la saisie du nom de sauvegarde et verrouiller la remise dans l’interface
- Afficher une fenêtre flottante de retour webhook et un formulaire inactif lorsque le client n’est pas reconnu
- Adapter la logique de sauvegarde et l’identification pour utiliser le champ Tarif et générer des fichiers datés YYMMJJ

## Tests
- Aucun test automatisé disponible


------
https://chatgpt.com/codex/tasks/task_b_68e4f2f3d3a48329b2ddcd2a1fe7ba70