### PR TITLE
feat: améliorer l'identification client et le menu

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -24,6 +24,10 @@
   line-height: 1.6;
 }
 
+main {
+  margin-top: calc(var(--site-nav-height) + 1.5rem);
+}
+
 ::selection {
   background-color: var(--color-primary);
   color: #fff;
@@ -132,6 +136,58 @@ textarea {
 .site-nav[data-collapsed='false'] {
   transform: translateY(0);
   box-shadow: 0 14px 40px -28px rgba(25, 63, 96, 0.55);
+}
+
+.site-nav__identity[hidden] {
+  display: none !important;
+}
+
+.site-nav__client {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  box-shadow: inset 0 1px 0 rgba(25, 63, 96, 0.08);
+}
+
+.site-nav__client[hidden] {
+  display: none !important;
+}
+
+.site-nav__client-text {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 14rem;
+}
+
+.site-nav__client-name {
+  margin: 0;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.site-nav__client-meta {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--color-muted-strong);
+}
+
+.site-nav__client-meta[hidden] {
+  display: none;
+}
+
+.site-nav__client-register {
+  margin: 0;
+  font-size: 0.75rem;
+}
+
+.site-nav__client-register a {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: underline;
 }
 
 .site-nav__inner {
@@ -466,6 +522,12 @@ textarea {
   line-height: 1.6;
 }
 
+.client-form-placeholder__content a {
+  color: var(--color-primary);
+  font-weight: 600;
+  text-decoration: underline;
+}
+
 .catalogue-header {
   position: sticky;
   top: calc(var(--site-nav-height) + 1rem);
@@ -553,6 +615,11 @@ textarea {
   background: #fff;
   color: var(--color-secondary);
   border: 1px solid rgba(25, 63, 96, 0.2);
+}
+
+.btn-secondary--compact {
+  padding: 0.5rem 0.85rem;
+  font-size: 0.8rem;
 }
 
 .btn-secondary:hover,
@@ -1298,7 +1365,7 @@ textarea {
 }
 
 .site-footer {
-  margin-top: 4rem;
+  margin-top: calc(var(--site-nav-height) + 2rem);
   background: var(--color-secondary);
   color: #e2e8f0;
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="true">
+    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
@@ -42,6 +42,20 @@
             </div>
             <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
           </form>
+          <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
+            <div class="site-nav__client-text">
+              <p id="client-identity-name" class="site-nav__client-name"></p>
+              <p id="client-identity-meta" class="site-nav__client-meta"></p>
+              <p id="client-identity-register" class="site-nav__client-register">
+                <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+                  >S'enregistrer comme nouveau client</a
+                >
+              </p>
+            </div>
+            <button id="client-identity-reset" type="button" class="btn-secondary btn-secondary--compact">
+              Modifier
+            </button>
+          </div>
           <div class="site-nav__save-group">
             <label for="save-name" class="save-name-field">
               <span>Nom de la sauvegarde</span>
@@ -363,8 +377,11 @@
       <div class="client-form-placeholder__content">
         <h2>Formulaire client</h2>
         <p>
-          Le client n'a pas été reconnu. Un formulaire d'inscription sera bientôt disponible pour compléter vos
-          informations.
+          Le client n'a pas été reconnu. Vous pouvez
+          <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+            >vous enregistrer comme nouveau client</a
+          >
+          pour accéder à nos services.
         </p>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- rendre la barre de navigation toujours visible et ajuster les espacements du contenu
- afficher l'identité client retournée par le webhook dans l'en-tête et proposer un lien d'inscription lorsque le nom est absent
- adapter la sauvegarde des paniers et le traitement de la remise issue du webhook

## Testing
- not run (non applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e5015eb69083299fd94b84de7b73cf