### PR TITLE
Rend la barre supérieure fixe et enrichit l'identification client

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -15,6 +15,7 @@
   --color-muted-strong: #4a5364;
   --color-border: #a5b7c6;
   --site-nav-height: 4.75rem;
+  --site-nav-offset: 0px;
 }
 
 .site-body {
@@ -105,6 +106,10 @@ textarea {
   box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.1);
 }
 
+.site-main {
+  padding-top: calc(var(--site-nav-offset) + 1.5rem) !important;
+}
+
 .rounded-2xl {
   border-radius: 0.9rem !important;
 }
@@ -132,6 +137,44 @@ textarea {
 .site-nav[data-collapsed='false'] {
   transform: translateY(0);
   box-shadow: 0 14px 40px -28px rgba(25, 63, 96, 0.55);
+}
+
+.site-nav__client-summary[hidden] {
+  display: none !important;
+}
+
+.site-nav__client-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.85rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  box-shadow: 0 5px 12px -10px rgba(25, 63, 96, 0.25);
+}
+
+.site-nav__client-summary-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-width: 12rem;
+}
+
+.site-nav__client-name {
+  font-weight: 700;
+  color: var(--color-secondary);
+  margin: 0;
+}
+
+.site-nav__client-meta {
+  font-size: 0.75rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+.site-nav__client-reset {
+  white-space: nowrap;
 }
 
 .site-nav__inner {
@@ -1298,7 +1341,7 @@ textarea {
 }
 
 .site-footer {
-  margin-top: 4rem;
+  margin-top: calc(var(--site-nav-offset) + 4rem);
   background: var(--color-secondary);
   color: #e2e8f0;
 }

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="true">
+    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
@@ -26,6 +26,15 @@
           <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite">Production</span>
         </div>
         <div class="site-nav__actions">
+          <div id="client-identity" class="site-nav__client-summary" hidden>
+            <div class="site-nav__client-summary-details">
+              <p id="client-summary-name" class="site-nav__client-name" aria-live="polite"></p>
+              <p id="client-summary-meta" class="site-nav__client-meta"></p>
+            </div>
+            <button id="client-reset" type="button" class="btn-secondary site-nav__client-reset">
+              Changer de client
+            </button>
+          </div>
           <form id="siret-form" class="site-nav__identity" autocomplete="off">
             <label for="siret-input" class="site-nav__identity-label">SIRET</label>
             <div class="site-nav__identity-controls">
@@ -69,7 +78,7 @@
         </div>
       </div>
     </nav>
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
+    <main class="site-main mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
           <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
@@ -363,8 +372,10 @@
       <div class="client-form-placeholder__content">
         <h2>Formulaire client</h2>
         <p>
-          Le client n'a pas été reconnu. Un formulaire d'inscription sera bientôt disponible pour compléter vos
-          informations.
+          Le client n'a pas été reconnu. Vous pouvez vous enregistrer comme nouveau client en suivant ce lien :
+          <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+            >https://www.idgroup-france.com/bao/NouveauClient.html</a
+          >.
         </p>
       </div>
     </section>


### PR DESCRIPTION
## Résumé
- Empêche la rétraction automatique du menu supérieur et lui ajoute un encart récapitulatif du client identifié.
- Ajuste la mise en page principale et le pied de page pour éviter toute superposition sous la barre fixe et propose un lien d'inscription quand le webhook ne renvoie pas de client.
- Met à jour le nom de fichier des sauvegardes et assainit la remise issue du webhook pour ne conserver que la valeur numérique.

## Tests
- N/A

------
https://chatgpt.com/codex/tasks/task_b_68e5015eb69083299fd94b84de7b73cf