### PR TITLE
Fixe le menu supérieur et enrichit la fiche client

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -22,6 +22,7 @@
   color: var(--color-muted-strong);
   font-family: var(--font-body);
   line-height: 1.6;
+  padding-top: calc(var(--site-nav-height) + 1.5rem);
 }
 
 ::selection {
@@ -341,6 +342,54 @@ textarea {
   font-weight: 600;
 }
 
+.site-nav__client-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  min-width: 18rem;
+}
+
+.site-nav__client-summary-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.site-nav__client-name {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+  margin: 0;
+}
+
+.site-nav__client-status {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted-strong);
+}
+
+.site-nav__client-action {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.site-nav__client-action a {
+  color: inherit;
+  text-decoration: underline;
+}
+
+.site-nav__client-action a:hover,
+.site-nav__client-action a:focus-visible {
+  color: var(--color-primary-dark);
+}
+
 .site-nav__identity button[disabled] {
   opacity: 0.6;
   cursor: progress;
@@ -355,6 +404,10 @@ textarea {
 
 .site-nav__cart-actions .btn-secondary {
   white-space: nowrap;
+}
+
+.site-main {
+  margin-top: 1rem;
 }
 
 .webhook-panel {

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="true">
+    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
@@ -42,6 +42,20 @@
             </div>
             <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
           </form>
+          <div id="client-summary" class="site-nav__identity site-nav__client-summary" hidden>
+            <div class="site-nav__client-summary-header">
+              <p id="client-summary-name" class="site-nav__client-name" aria-live="polite"></p>
+              <button id="client-summary-reset" type="button" class="btn-secondary">Changer</button>
+            </div>
+            <p id="client-summary-status" class="site-nav__client-status"></p>
+            <p id="client-summary-action" class="site-nav__client-action" hidden>
+              <a
+                href="https://www.idgroup-france.com/bao/NouveauClient.html"
+                target="_blank"
+                rel="noopener"
+              >S'enregistrer comme nouveau client</a>
+            </p>
+          </div>
           <div class="site-nav__save-group">
             <label for="save-name" class="save-name-field">
               <span>Nom de la sauvegarde</span>
@@ -69,7 +83,7 @@
         </div>
       </div>
     </nav>
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
+    <main class="site-main mx-auto w-full max-w-[120rem] px-4 pb-24">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
           <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">


### PR DESCRIPTION
## Résumé
- Désactivation du repli automatique du menu fixe et ajout d'un espacement global pour éviter que le catalogue et le pied de page ne soient masqués.
- Ajout d'un récapitulatif client dans la barre supérieure avec possibilité de réinitialisation, suggestion d'inscription et nouvelle logique de remise issue du webhook.
- Adaptation de la sauvegarde du panier pour inclure le nom saisi, les trois premières lettres du client et la date tout en nettoyant la valeur de remise fournie par le webhook.

## Tests
- Non réalisés (interface statique)


------
https://chatgpt.com/codex/tasks/task_b_68e5015eb69083299fd94b84de7b73cf