### PR TITLE
Adapter le menu et l'identification client

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -15,6 +15,7 @@
   --color-muted-strong: #4a5364;
   --color-border: #a5b7c6;
   --site-nav-height: 4.75rem;
+  --site-nav-offset: var(--site-nav-height);
 }
 
 .site-body {
@@ -22,6 +23,10 @@
   color: var(--color-muted-strong);
   font-family: var(--font-body);
   line-height: 1.6;
+}
+
+.site-main {
+  padding-top: calc(var(--site-nav-offset, var(--site-nav-height)) + 3.5rem);
 }
 
 ::selection {
@@ -122,11 +127,6 @@ textarea {
   backdrop-filter: blur(12px);
   border-bottom: 3px solid var(--color-primary);
   transition: transform 200ms ease, box-shadow 200ms ease;
-}
-
-.site-nav[data-collapsed='true'] {
-  transform: translateY(calc(-100% + 1.8rem));
-  box-shadow: none;
 }
 
 .site-nav[data-collapsed='false'] {
@@ -317,6 +317,63 @@ textarea {
   color: var(--color-muted-strong);
 }
 
+.site-nav__identity-display {
+  gap: 0.35rem;
+}
+
+.site-nav__identity-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.site-nav__identity-name {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.site-nav__identity-details {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted-strong);
+}
+
+.site-nav__identity-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.site-nav__identity-register {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.site-nav__identity-register:hover,
+.site-nav__identity-register:focus-visible {
+  color: var(--color-primary-dark);
+  text-decoration: underline;
+}
+
+.site-nav__identity-register:focus-visible {
+  outline: 3px solid rgba(228, 30, 40, 0.2);
+  outline-offset: 2px;
+}
+
+.site-nav__identity-reset {
+  padding-inline: 1rem;
+}
+
 .site-nav__identity[data-status='loading'] .site-nav__identity-feedback {
   color: var(--color-secondary);
 }
@@ -466,9 +523,28 @@ textarea {
   line-height: 1.6;
 }
 
+.client-form-placeholder__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-top: 0.85rem;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+.client-form-placeholder__link:hover,
+.client-form-placeholder__link:focus-visible {
+  color: var(--color-primary-dark);
+  text-decoration: underline;
+}
+
 .catalogue-header {
   position: sticky;
-  top: calc(var(--site-nav-height) + 1rem);
+  top: calc(var(--site-nav-offset, var(--site-nav-height)) + 1rem);
   z-index: 10;
   backdrop-filter: blur(6px);
   isolation: isolate;

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="true">
+    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
@@ -42,6 +42,30 @@
             </div>
             <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
           </form>
+          <div
+            id="client-identity-display"
+            class="site-nav__identity site-nav__identity-display hidden"
+            aria-live="polite"
+          >
+            <div class="site-nav__identity-summary">
+              <p id="client-identity-name" class="site-nav__identity-name"></p>
+              <p id="client-identity-details" class="site-nav__identity-details"></p>
+            </div>
+            <div class="site-nav__identity-actions">
+              <a
+                id="client-identity-register"
+                class="site-nav__identity-register hidden"
+                href="https://www.idgroup-france.com/bao/NouveauClient.html"
+                target="_blank"
+                rel="noopener"
+              >
+                S'enregistrer comme nouveau client
+              </a>
+              <button id="reset-identification" type="button" class="btn-secondary site-nav__identity-reset">
+                Changer de client
+              </button>
+            </div>
+          </div>
           <div class="site-nav__save-group">
             <label for="save-name" class="save-name-field">
               <span>Nom de la sauvegarde</span>
@@ -69,7 +93,7 @@
         </div>
       </div>
     </nav>
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
+    <main class="site-main mx-auto w-full max-w-[120rem] px-4 pb-32">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
           <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
@@ -362,10 +386,18 @@
     <section id="client-form-placeholder" class="client-form-placeholder" aria-live="polite" data-open="false">
       <div class="client-form-placeholder__content">
         <h2>Formulaire client</h2>
-        <p>
-          Le client n'a pas été reconnu. Un formulaire d'inscription sera bientôt disponible pour compléter vos
-          informations.
+        <p id="client-form-placeholder-message">
+          Le client n'a pas été reconnu. Vous pouvez vous enregistrer comme nouveau client via le lien ci-dessous.
         </p>
+        <a
+          id="client-form-placeholder-link"
+          class="client-form-placeholder__link"
+          href="https://www.idgroup-france.com/bao/NouveauClient.html"
+          target="_blank"
+          rel="noopener"
+        >
+          S'enregistrer comme nouveau client
+        </a>
       </div>
     </section>
 
@@ -377,7 +409,7 @@
       <div id="webhook-panel-content" class="webhook-panel__content"></div>
     </div>
 
-    <footer class="site-footer">
+    <footer class="site-footer mt-20">
       <div class="footer-inner">
         <div>
           <p class="text-lg font-semibold text-white">ID GROUP Devis</p>


### PR DESCRIPTION
## Résumé
- supprime le repli automatique du menu et ajuste les espacements de la page
- affiche les informations client dans l’entête lorsqu’un webhook identifie le SIRET et propose un lien d’inscription sinon
- renomme les sauvegardes en intégrant les initiales client et nettoie la remise transmise par le webhook

## Tests
- Aucun test automatisé n’a été exécuté (application statique)

------
https://chatgpt.com/codex/tasks/task_b_68e5015eb69083299fd94b84de7b73cf