### PR TITLE
Ajout du bouton de commande et ajustements d'interface

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -208,8 +208,8 @@ textarea {
 }
 
 .brand-logo {
-  width: 2.75rem;
-  height: 2.75rem;
+  width: 4.125rem;
+  height: 4.125rem;
   object-fit: contain;
   cursor: pointer;
 }

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
           <p class="brand-title">ID GROUP Devis</p>
-          <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite">Production</span>
         </div>
         <div class="site-nav__actions">
           <form id="siret-form" class="site-nav__identity" autocomplete="off">
@@ -58,7 +57,7 @@
           </div>
           <div class="site-nav__save-group">
             <label for="save-name" class="save-name-field">
-              <span>Nom de la sauvegarde</span>
+              <span>Proposition</span>
               <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
             </label>
             <div class="site-nav__cart-actions">
@@ -72,7 +71,10 @@
             <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
           </div>
           <button id="generate-pdf" class="btn-primary">
-            Générer le devis PDF
+            Imprimer
+          </button>
+          <button id="submit-order" class="btn-primary">
+            Passer commande
           </button>
           <div class="site-nav__tree">
             <label for="catalogue-tree" class="site-nav__tree-label">Arborescence du catalogue</label>


### PR DESCRIPTION
## Résumé
- Renommer la zone de sauvegarde en « Proposition », retirer l’indicateur de mode webhook et agrandir le logo.
- Remplacer l’action « Générer le devis PDF » par « Imprimer » et ajouter le bouton « Passer commande ».
- Envoyer le PDF généré et l’export JSON du panier vers le webhook IDGROUP après confirmation utilisateur.

## Tests
- Non exécuté (application front-end uniquement).


------
https://chatgpt.com/codex/tasks/task_b_68e50f11206483299cb3b14df2727c3c