### PR TITLE
Ajout du bouton Passer commande et renommage de la proposition

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,7 +14,7 @@
   --color-muted: #9297aa;
   --color-muted-strong: #4a5364;
   --color-border: #a5b7c6;
-  --site-nav-height: 4.75rem;
+  --site-nav-height: 5.5rem;
 }
 
 .site-body {
@@ -208,10 +208,9 @@ textarea {
 }
 
 .brand-logo {
-  width: 2.75rem;
-  height: 2.75rem;
+  width: 4.125rem;
+  height: 4.125rem;
   object-fit: contain;
-  cursor: pointer;
 }
 
 .brand-title {
@@ -298,28 +297,6 @@ textarea {
   font-size: 0.85rem;
   color: var(--color-muted-strong);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.webhook-mode-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: 0.5rem;
-  padding: 0.25rem 0.65rem;
-  border-radius: 9999px;
-  background: rgba(25, 63, 96, 0.08);
-  color: var(--color-secondary);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid rgba(25, 63, 96, 0.12);
-}
-
-.webhook-mode-badge[data-mode='test'] {
-  background: rgba(234, 97, 26, 0.12);
-  border-color: rgba(234, 97, 26, 0.35);
-  color: var(--color-accent);
 }
 
 .site-nav__identity {
@@ -598,6 +575,16 @@ textarea {
   background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
   color: #fff;
   box-shadow: 0 12px 24px -16px var(--color-primary);
+}
+
+.btn-primary--order {
+  background: linear-gradient(135deg, var(--color-secondary), #24527d);
+  box-shadow: 0 12px 24px -16px rgba(25, 63, 96, 0.6);
+}
+
+.btn-primary--order:hover,
+.btn-primary--order:focus-visible {
+  box-shadow: 0 18px 32px -16px rgba(25, 63, 96, 0.55);
 }
 
 .btn-primary:hover,

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
           <p class="brand-title">ID GROUP Devis</p>
-          <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite">Production</span>
         </div>
         <div class="site-nav__actions">
           <form id="siret-form" class="site-nav__identity" autocomplete="off">
@@ -58,8 +57,8 @@
           </div>
           <div class="site-nav__save-group">
             <label for="save-name" class="save-name-field">
-              <span>Nom de la sauvegarde</span>
-              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
+              <span>Nom de la proposition</span>
+              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Proposition magasin" />
             </label>
             <div class="site-nav__cart-actions">
               <button id="save-cart" type="button" class="btn-secondary">Sauvegarder</button>
@@ -72,7 +71,10 @@
             <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
           </div>
           <button id="generate-pdf" class="btn-primary">
-            Générer le devis PDF
+            Imprimer
+          </button>
+          <button id="place-order" type="button" class="btn-primary btn-primary--order">
+            Passer commande
           </button>
           <div class="site-nav__tree">
             <label for="catalogue-tree" class="site-nav__tree-label">Arborescence du catalogue</label>


### PR DESCRIPTION
## Summary
- renommer les libellés de sauvegarde en "proposition", ajuster le bouton "Imprimer" et agrandir le logo
- retirer l’indicateur d’état du webhook et ajouter le bouton "Passer commande" avec confirmation et envoi au webhook fourni
- factoriser la génération du PDF pour réutilisation lors de l’impression et de l’envoi de la commande, transmettre le PDF et la sauvegarde JSON

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e50f11206483299cb3b14df2727c3c