### PR TITLE
Ajout du bouton de commande et ajustements de la navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -208,10 +208,9 @@ textarea {
 }
 
 .brand-logo {
-  width: 2.75rem;
-  height: 2.75rem;
+  width: 4.125rem;
+  height: 4.125rem;
   object-fit: contain;
-  cursor: pointer;
 }
 
 .brand-title {
@@ -298,28 +297,6 @@ textarea {
   font-size: 0.85rem;
   color: var(--color-muted-strong);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
-}
-
-.webhook-mode-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: 0.5rem;
-  padding: 0.25rem 0.65rem;
-  border-radius: 9999px;
-  background: rgba(25, 63, 96, 0.08);
-  color: var(--color-secondary);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid rgba(25, 63, 96, 0.12);
-}
-
-.webhook-mode-badge[data-mode='test'] {
-  background: rgba(234, 97, 26, 0.12);
-  border-color: rgba(234, 97, 26, 0.35);
-  color: var(--color-accent);
 }
 
 .site-nav__identity {

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
         <div class="site-nav__branding">
           <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
           <p class="brand-title">ID GROUP Devis</p>
-          <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite">Production</span>
         </div>
         <div class="site-nav__actions">
           <form id="siret-form" class="site-nav__identity" autocomplete="off">
@@ -58,7 +57,7 @@
           </div>
           <div class="site-nav__save-group">
             <label for="save-name" class="save-name-field">
-              <span>Nom de la sauvegarde</span>
+              <span>Proposition</span>
               <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
             </label>
             <div class="site-nav__cart-actions">
@@ -72,7 +71,10 @@
             <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
           </div>
           <button id="generate-pdf" class="btn-primary">
-            Générer le devis PDF
+            Imprimer
+          </button>
+          <button id="submit-order" type="button" class="btn-primary">
+            Passer commande
           </button>
           <div class="site-nav__tree">
             <label for="catalogue-tree" class="site-nav__tree-label">Arborescence du catalogue</label>


### PR DESCRIPTION
## Résumé
- renommage de la zone de proposition et suppression de l'indicateur de webhook dans la barre supérieure
- ajout d'un bouton « Passer commande » avec envoi du PDF et du panier JSON au webhook dédié
- adaptation du générateur de PDF pour réutiliser le document sans téléchargement automatique

## Tests
- Aucun test automatisé

------
https://chatgpt.com/codex/tasks/task_b_68e50f11206483299cb3b14df2727c3c