### PR TITLE
Ajout du mode debug et orientation formulaire nouveau client

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -25,7 +25,7 @@
 }
 
 main {
-  margin-top: calc(var(--site-nav-height) + 1.5rem);
+  margin-top: calc(var(--site-nav-height) + 1.5rem - 20px);
 }
 
 ::selection {
@@ -479,6 +479,103 @@ textarea {
 .webhook-panel__content p {
   margin: 0;
   line-height: 1.45;
+}
+
+.debug-tooltip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 9999;
+  pointer-events: none;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.45rem;
+  background: rgba(25, 63, 96, 0.95);
+  color: #fff;
+  font-size: 0.75rem;
+  line-height: 1.2;
+  box-shadow: 0 18px 40px -24px rgba(25, 63, 96, 0.8);
+  opacity: 0;
+  transform: translate3d(0, 0, 0);
+  transition: opacity 120ms ease;
+}
+
+.debug-tooltip[data-visible='true'] {
+  opacity: 1;
+}
+
+.debug-panel {
+  position: fixed;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: min(26rem, 95vw);
+  max-height: min(26rem, 80vh);
+  padding: 0.75rem;
+  border-radius: 0.85rem;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  box-shadow: 0 32px 70px -36px rgba(25, 63, 96, 0.65);
+  z-index: 60;
+  backdrop-filter: blur(6px);
+  overflow: hidden;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+.debug-panel[data-visible='true'] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.debug-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  cursor: grab;
+  user-select: none;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.debug-panel__header:active {
+  cursor: grabbing;
+}
+
+.debug-panel__title {
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.debug-panel__content {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.8rem;
+  color: var(--color-muted-strong);
+}
+
+.debug-panel__entry {
+  display: grid;
+  gap: 0.15rem;
+  padding: 0.45rem 0.5rem;
+  border-radius: 0.65rem;
+  background: rgba(25, 63, 96, 0.06);
+  border: 1px solid rgba(25, 63, 96, 0.1);
+}
+
+.debug-panel__entry strong {
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.debug-panel__entry time {
+  font-size: 0.7rem;
+  color: var(--color-muted);
 }
 
 .webhook-panel__list {


### PR DESCRIPTION
## Résumé
- rediriger explicitement les utilisateurs vers le formulaire nouveau client en cas d'échec d'identification SIRET
- réduire l'espacement sous la barre de navigation et ajouter des info-bulles sur les champs
- introduire un mode debug avec panneau flottant journalisant les actions et un survol informatif des éléments

## Tests
- non exécutés (application statique)

------
https://chatgpt.com/codex/tasks/task_b_68e5199a8db8832993aa960d49c61a1d