### PR TITLE
Amélioration du guidage SIRET et du mode debug

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -25,7 +25,7 @@
 }
 
 main {
-  margin-top: calc(var(--site-nav-height) + 1.5rem);
+  margin-top: calc(var(--site-nav-height) + 1.5rem - 20px);
 }
 
 ::selection {
@@ -1417,6 +1417,93 @@ textarea {
 .quote-summary-panel dl {
   display: grid;
   gap: 0.6rem;
+}
+
+.debug-panel {
+  position: fixed;
+  top: 6rem;
+  right: 1.5rem;
+  width: min(22rem, calc(100vw - 2rem));
+  max-height: 60vh;
+  background: var(--color-surface);
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  box-shadow: 0 18px 40px -24px rgba(25, 63, 96, 0.6);
+  border-radius: 0.75rem;
+  display: none;
+  z-index: 1000;
+  overflow: hidden;
+}
+
+.debug-panel[data-open='true'] {
+  display: flex;
+  flex-direction: column;
+}
+
+.debug-panel__header {
+  background: var(--color-secondary);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: move;
+  user-select: none;
+}
+
+.debug-panel__body {
+  padding: 0.75rem 1rem 1rem;
+  background: var(--color-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  overflow-y: auto;
+  flex: 1 1 auto;
+}
+
+.debug-panel__entry {
+  background: var(--color-surface);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(25, 63, 96, 0.08);
+  box-shadow: 0 1px 4px rgba(25, 63, 96, 0.08);
+  font-size: 0.85rem;
+}
+
+.debug-panel__timestamp {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--color-muted);
+  margin-bottom: 0.25rem;
+}
+
+.debug-panel__message {
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.debug-panel__details {
+  margin: 0.35rem 0 0;
+  padding: 0.45rem 0.5rem;
+  background: rgba(25, 63, 96, 0.06);
+  border-radius: 0.35rem;
+  color: var(--color-muted-strong);
+  font-family: var(--font-body);
+  font-size: 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.debug-tooltip {
+  position: fixed;
+  pointer-events: none;
+  background: rgba(25, 63, 96, 0.92);
+  color: #fff;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.4rem;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  box-shadow: 0 12px 24px -16px rgba(25, 63, 96, 0.8);
+  z-index: 1100;
+  max-width: 18rem;
 }
 
 @media (max-width: 1024px) {


### PR DESCRIPTION
## Résumé
- Oriente l'utilisateur vers le formulaire Nouveau client lors des erreurs d'identification SIRET et trace les échanges webhook.
- Ajoute un mode debug activable via le champ Proposition avec panneau flottant et info-bulles automatiques sur les champs.
- Réduit la marge sous la navigation principale et fournit les styles associés au panneau et à l'info-bulle de debug.

## Tests
- `node --check js/app.js`


------
https://chatgpt.com/codex/tasks/task_b_68e5199a8db8832993aa960d49c61a1d