### PR TITLE
Ajout du mode debug et amélioration des retours SIRET

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -25,7 +25,7 @@
 }
 
 main {
-  margin-top: calc(var(--site-nav-height) + 1.5rem);
+  margin-top: calc(var(--site-nav-height) + 1.5rem - 20px);
 }
 
 ::selection {
@@ -1538,4 +1538,105 @@ textarea {
 .site-body a:focus-visible {
   color: var(--color-primary-dark);
   text-decoration: underline;
+}
+
+body[data-debug-mode='true'] {
+  cursor: crosshair;
+}
+
+.debug-panel {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  width: min(22rem, calc(100vw - 3rem));
+  max-height: min(24rem, calc(100vh - 4rem));
+  display: flex;
+  flex-direction: column;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(25, 63, 96, 0.2);
+  box-shadow: 0 20px 45px -25px rgba(25, 63, 96, 0.65);
+  overflow: hidden;
+  z-index: 60;
+}
+
+.debug-panel[hidden] {
+  display: none !important;
+}
+
+.debug-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.65rem 1rem;
+  background: rgba(25, 63, 96, 0.9);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: grab;
+  user-select: none;
+  touch-action: none;
+}
+
+.debug-panel__content {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  background: rgba(25, 63, 96, 0.03);
+}
+
+.debug-panel__entry {
+  font-size: 0.75rem;
+  line-height: 1.4;
+  color: var(--color-secondary);
+  padding: 0.45rem 0.6rem;
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 0.65rem;
+  border: 1px solid rgba(25, 63, 96, 0.08);
+  box-shadow: inset 0 1px 0 rgba(25, 63, 96, 0.06);
+}
+
+.debug-panel__timestamp {
+  font-weight: 700;
+  margin-right: 0.35rem;
+  color: var(--color-primary);
+}
+
+.debug-panel__details {
+  margin-top: 0.35rem;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  background: rgba(25, 63, 96, 0.06);
+  font-family: 'Fira Code', 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+  font-size: 0.7rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.debug-tooltip {
+  position: fixed;
+  z-index: 70;
+  pointer-events: none;
+  padding: 0.35rem 0.55rem;
+  border-radius: 0.6rem;
+  background: rgba(25, 63, 96, 0.92);
+  color: #fff;
+  font-size: 0.7rem;
+  line-height: 1.4;
+  box-shadow: 0 10px 30px -18px rgba(25, 63, 96, 0.8);
+  max-width: 18rem;
+}
+
+.debug-tooltip[hidden] {
+  display: none !important;
+}
+
+[data-debug-highlight='true'] {
+  outline: 2px dashed var(--color-accent);
+  outline-offset: 2px;
 }


### PR DESCRIPTION
## Résumé
- améliore les messages d’erreur SIRET en invitant l’utilisateur à remplir le formulaire nouveau client et ouvre le rappel dédié
- ajoute un mode debug déclenché par la valeur « debug » dans le champ Proposition avec panneau flottant, survol informatif et journalisation des actions
- complète les info-bulles des champs et réduit l’espace entre la navigation et le contenu principal

## Tests
- ⚠️ non exécutés (non demandés)


------
https://chatgpt.com/codex/tasks/task_b_68e5199a8db8832993aa960d49c61a1d