### PR TITLE
feat: add order confirmation modal and icon actions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -561,7 +561,7 @@ textarea {
   align-items: center;
   gap: 0.5rem;
   padding: 0.45rem 0.75rem;
-  border-radius: 999px;
+  border-radius: 0.85rem;
   background: var(--color-soft);
   border: 1px solid rgba(25, 63, 96, 0.15);
   text-transform: uppercase;
@@ -620,6 +620,48 @@ textarea {
 .btn-secondary--compact {
   padding: 0.5rem 0.85rem;
   font-size: 0.8rem;
+}
+
+.btn-icon {
+  width: 2.75rem;
+  height: 2.75rem;
+  min-width: 2.75rem;
+  padding: 0.5rem;
+  line-height: 1;
+  gap: 0;
+}
+
+.btn-icon svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  pointer-events: none;
+}
+
+.icon-only-label {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.75rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(25, 63, 96, 0.15);
+  color: var(--color-secondary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  cursor: pointer;
+}
+
+.icon-only-label svg {
+  width: 1.35rem;
+  height: 1.35rem;
+  pointer-events: none;
+}
+
+.icon-only-label:hover,
+.icon-only-label:focus-visible {
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
+  background: #fff;
 }
 
 .btn-secondary:hover,
@@ -1018,6 +1060,100 @@ textarea {
 .siret-modal-actions {
   flex-wrap: wrap;
   justify-content: flex-start;
+}
+
+#siret-error-link,
+#siret-error-link:visited {
+  color: #fff;
+}
+
+#order-confirmation-modal .modal-card {
+  max-width: 36rem;
+}
+
+.order-modal-body {
+  gap: 1.5rem;
+}
+
+.order-modal-title {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.order-modal-description {
+  font-size: 0.95rem;
+  color: var(--color-muted-strong);
+  line-height: 1.6;
+}
+
+.order-modal-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.order-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.order-modal-field label {
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+  font-weight: 700;
+}
+
+.order-modal-field input {
+  border: 1px solid rgba(25, 63, 96, 0.2);
+  border-radius: 0.65rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.order-modal-field input:focus {
+  outline: none;
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.18);
+}
+
+.order-modal-field--full {
+  grid-column: 1 / -1;
+}
+
+.order-modal-checkbox {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  font-size: 0.9rem;
+  color: var(--color-muted-strong);
+}
+
+.order-modal-checkbox input {
+  margin-top: 0.25rem;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 1px solid rgba(25, 63, 96, 0.25);
+  border-radius: 0.25rem;
+}
+
+.order-modal-checkbox span {
+  flex: 1;
+}
+
+.order-modal-actions {
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+#order-confirmation-submit[data-loading='true'] {
+  cursor: progress;
+  opacity: 0.7;
 }
 
 .quote-row {
@@ -1512,6 +1648,12 @@ textarea {
     width: 100%;
   }
 
+  .site-nav__actions .btn-primary.btn-icon,
+  .site-nav__actions .btn-secondary.btn-icon,
+  .site-nav__cart-actions .btn-secondary.btn-icon {
+    width: auto;
+  }
+
   .site-nav__save-group {
     flex-direction: column;
     align-items: stretch;
@@ -1524,6 +1666,20 @@ textarea {
   }
 
   .site-nav__cart-actions .btn-secondary {
+    width: 100%;
+  }
+
+  .order-modal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .order-modal-actions {
+    flex-direction: column-reverse;
+    align-items: stretch;
+  }
+
+  .order-modal-actions .btn-primary,
+  .order-modal-actions .btn-secondary {
     width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -37,7 +37,17 @@
                 placeholder="Numéro SIRET (14 chiffres)"
                 class="site-nav__identity-input"
               />
-              <button id="siret-submit" type="submit" class="btn-secondary">Identifier</button>
+              <button
+                id="siret-submit"
+                type="submit"
+                class="btn-secondary btn-icon"
+                title="Identifier le client"
+                aria-label="Identifier le client"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
+                </svg>
+              </button>
             </div>
             <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
           </form>
@@ -51,8 +61,21 @@
                 >
               </p>
             </div>
-            <button id="client-identity-reset" type="button" class="btn-secondary btn-secondary--compact">
-              Modifier
+            <button
+              id="client-identity-reset"
+              type="button"
+              class="btn-secondary btn-icon"
+              title="Modifier le client identifié"
+              aria-label="Modifier le client identifié"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="m16.862 4.487 1.651-1.651a2.25 2.25 0 1 1 3.182 3.182L7.5 20.213 3 21l.787-4.5L16.862 4.487z"
+                />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 7.5 16.5 4.5" />
+              </svg>
             </button>
           </div>
           <div class="site-nav__save-group">
@@ -61,23 +84,86 @@
               <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
             </label>
             <div class="site-nav__cart-actions">
-              <button id="save-cart" type="button" class="btn-secondary">Sauvegarder</button>
-              <button id="restore-cart" type="button" class="btn-secondary">Restaurer</button>
+              <button
+                id="save-cart"
+                type="button"
+                class="btn-secondary btn-icon"
+                title="Sauvegarder le panier"
+                aria-label="Sauvegarder le panier"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M3 16.5v1.125A2.625 2.625 0 0 0 5.625 20.25h12.75A2.625 2.625 0 0 0 21 17.625V16.5M7.5 10.5 12 15l4.5-4.5M12 4.5v10.125"
+                  />
+                </svg>
+              </button>
+              <button
+                id="restore-cart"
+                type="button"
+                class="btn-secondary btn-icon"
+                title="Restaurer un panier sauvegardé"
+                aria-label="Restaurer un panier sauvegardé"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M16.023 9.348h4.992m0 0V4.356m0 4.992-3.284-3.284A8.25 8.25 0 1 0 5.228 18.772"
+                  />
+                </svg>
+              </button>
               <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
             </div>
           </div>
           <div class="discount-field" aria-live="polite">
-            <span>Remise client</span>
+            <span>Remise</span>
             <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
           </div>
-          <button id="generate-pdf" class="btn-primary">
-            Imprimer
+          <button
+            id="generate-pdf"
+            type="button"
+            class="btn-primary btn-icon"
+            title="Imprimer le devis"
+            aria-label="Imprimer le devis"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M6.75 7.5V3.75A2.25 2.25 0 0 1 9 1.5h6a2.25 2.25 0 0 1 2.25 2.25V7.5M6.75 7.5h10.5m-10.5 0H4.5A2.25 2.25 0 0 0 2.25 9.75v6A2.25 2.25 0 0 0 4.5 18h2.25m10.5-10.5H19.5a2.25 2.25 0 0 1 2.25 2.25v6A2.25 2.25 0 0 1 19.5 18h-2.25m0 0v3.75A2.25 2.25 0 0 1 15 24H9a2.25 2.25 0 0 1-2.25-2.25V18m10.5 0H6.75"
+              />
+            </svg>
           </button>
-          <button id="submit-order" class="btn-primary">
-            Passer commande
+          <button
+            id="submit-order"
+            type="button"
+            class="btn-primary btn-icon"
+            title="Passer commande"
+            aria-label="Passer commande"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M2.25 3h1.386a.75.75 0 0 1 .728.546l.383 1.437M6.75 15.75h10.5l1.5-9H5.106m1.644 9L5.447 5.403a.75.75 0 0 0-.729-.553H2.25"
+              />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M8.25 19.5a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Zm8.25 0a.75.75 0 1 0 0 1.5.75.75 0 0 0 0-1.5Z" />
+            </svg>
           </button>
           <div class="site-nav__tree">
-            <label for="catalogue-tree" class="site-nav__tree-label">Arborescence du catalogue</label>
+            <label
+              for="catalogue-tree"
+              class="site-nav__tree-label icon-only-label"
+              title="Sélectionner une catégorie ou un article"
+              aria-label="Sélectionner une catégorie ou un article"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 6h15M4.5 12h15M4.5 18h15" />
+              </svg>
+              <span class="sr-only">Sélectionner une catégorie ou un article</span>
+            </label>
             <select id="catalogue-tree" class="site-nav__tree-select">
               <option value="">Sélectionner une catégorie ou un article</option>
             </select>
@@ -395,6 +481,79 @@
             <button id="siret-error-close" type="button" class="btn-secondary">Fermer</button>
           </div>
         </div>
+      </div>
+    </div>
+
+    <div
+      id="order-confirmation-modal"
+      class="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="order-confirmation-title"
+      data-open="false"
+    >
+      <div class="modal-card order-modal-card">
+        <form id="order-confirmation-form" class="modal-body order-modal-body">
+          <h2 id="order-confirmation-title" class="order-modal-title">Confirmer la commande</h2>
+          <p class="order-modal-description">
+            Veuillez confirmer les informations du contact qui passera commande. Les informations préremplies proviennent de
+            l'identification client et peuvent être ajustées avant envoi.
+          </p>
+          <div class="order-modal-grid">
+            <div class="order-modal-field">
+              <label for="order-contact-last-name">Nom</label>
+              <input
+                id="order-contact-last-name"
+                name="orderContactLastName"
+                type="text"
+                autocomplete="family-name"
+              />
+            </div>
+            <div class="order-modal-field">
+              <label for="order-contact-first-name">Prénom</label>
+              <input
+                id="order-contact-first-name"
+                name="orderContactFirstName"
+                type="text"
+                autocomplete="given-name"
+              />
+            </div>
+            <div class="order-modal-field order-modal-field--full">
+              <label for="order-contact-email">E-mail</label>
+              <input
+                id="order-contact-email"
+                name="orderContactEmail"
+                type="email"
+                autocomplete="email"
+                required
+              />
+            </div>
+            <div class="order-modal-field order-modal-field--full">
+              <label for="order-contact-phone">Téléphone</label>
+              <input
+                id="order-contact-phone"
+                name="orderContactPhone"
+                type="tel"
+                autocomplete="tel"
+              />
+            </div>
+          </div>
+          <label class="order-modal-checkbox">
+            <input
+              id="order-contact-copy"
+              name="orderContactCopy"
+              type="checkbox"
+              checked
+            />
+            <span>Je souhaite recevoir une copie de la demande.</span>
+          </label>
+          <div class="modal-actions order-modal-actions">
+            <button id="order-confirmation-cancel" type="button" class="btn-secondary">Annuler</button>
+            <button id="order-confirmation-submit" type="submit" class="btn-primary">
+              <span id="order-confirmation-submit-label">Envoyer la commande</span>
+            </button>
+          </div>
+        </form>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- replace header actions with icon-only buttons and adjust styling/tooltips
- introduce a contact confirmation modal before submitting orders and send details to the webhook
- improve SIRET error message visibility and reuse webhook contact data including phone numbers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e61d6575b08329b68306d152696ac4