### PR TITLE
feat: proposer des modes d'affichage adaptatifs

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -231,61 +231,12 @@ textarea {
   gap: 0.75rem;
 }
 
-.site-nav__save-group {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.save-name-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 63, 96, 0.15);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.save-name-field input {
-  border: 1px solid rgba(25, 63, 96, 0.2);
-  border-radius: 0.6rem;
-  padding: 0.45rem 0.6rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--color-secondary);
-  background: #fff;
-  min-width: 12rem;
-}
-
-.save-name-field input:focus {
-  outline: none;
-  border-color: var(--color-secondary);
-  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
-}
-
 .site-nav__tree {
   display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  min-width: 10rem;
-  flex: 0 1 12rem;
-  width: min(100%, 14rem);
-  margin-left: auto;
-}
-
-.site-nav__tree-label {
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
+  align-items: center;
+  min-width: 8rem;
+  flex: 0 1 10rem;
+  width: min(100%, 12rem);
 }
 
 .site-nav__tree-select {
@@ -294,8 +245,8 @@ textarea {
   border-radius: 0.6rem;
   border: 1px solid rgba(25, 63, 96, 0.15);
   background: rgba(255, 255, 255, 0.9);
-  padding: 0.55rem 0.75rem;
-  font-size: 0.85rem;
+  padding: 0.45rem 0.6rem;
+  font-size: 0.8rem;
   color: var(--color-muted-strong);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -488,6 +439,58 @@ textarea {
   font-size: 0.85rem;
 }
 
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(25, 63, 96, 0.25);
+  backdrop-filter: blur(3px);
+  z-index: 80;
+}
+
+.loading-overlay[hidden] {
+  display: none;
+}
+
+.loading-overlay__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.75rem 2.25rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  box-shadow: 0 24px 48px -24px rgba(25, 63, 96, 0.55);
+}
+
+.loading-overlay__icon {
+  font-size: 2rem;
+  animation: loading-overlay-pulse 1.2s ease-in-out infinite;
+}
+
+.loading-overlay__text {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+  text-align: center;
+}
+
+@keyframes loading-overlay-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(0.9);
+    opacity: 0.7;
+  }
+}
+
 .client-form-placeholder {
   max-width: 50rem;
   margin: 0 auto 2.5rem;
@@ -621,6 +624,42 @@ textarea {
 .btn-icon .icon {
   width: 1.25rem;
   height: 1.25rem;
+}
+
+.display-mode-toggle {
+  position: relative;
+}
+
+.display-mode-toggle__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  font-size: 1.25rem;
+}
+
+.display-mode-toggle__icon::before {
+  display: inline-block;
+  transform: none;
+}
+
+.display-mode-toggle[data-mode='desktop'] .display-mode-toggle__icon::before {
+  content: '\1F5A5';
+}
+
+.display-mode-toggle[data-mode='tablet'] .display-mode-toggle__icon::before {
+  content: '\1F4F1';
+  transform: scaleX(1.1);
+}
+
+.display-mode-toggle[data-mode='phone'] .display-mode-toggle__icon::before {
+  content: '\1F4F1';
+  transform: scaleX(0.8);
+}
+
+.display-mode-toggle[data-mode='auto'] .display-mode-toggle__icon::before {
+  content: '\2699';
 }
 
 [data-tooltip] {
@@ -1191,6 +1230,73 @@ textarea {
   justify-content: flex-end;
 }
 
+.save-cart-modal-card {
+  max-width: 26rem;
+}
+
+.save-cart-modal-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.save-cart-modal-title {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+  margin: 0;
+}
+
+.save-cart-modal-intro {
+  font-size: 0.95rem;
+  color: var(--color-muted-strong);
+  margin: 0;
+}
+
+.save-cart-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--color-muted-strong);
+}
+
+.save-cart-modal-field span {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--color-muted);
+}
+
+.save-cart-modal-field input {
+  border-radius: 0.65rem;
+  border: 1px solid rgba(25, 63, 96, 0.2);
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+  background: #fff;
+}
+
+.save-cart-modal-field input:focus {
+  outline: none;
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
+}
+
+.save-cart-modal-feedback {
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  margin: 0;
+}
+
+.save-cart-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
 .quote-row {
   display: flex;
   flex-direction: column;
@@ -1620,6 +1726,113 @@ textarea {
   gap: 0.6rem;
 }
 
+body[data-display-mode='tablet'] .site-nav__inner,
+body[data-display-mode='phone'] .site-nav__inner {
+  flex-direction: column !important;
+  align-items: flex-start !important;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='tablet'] .site-nav__actions,
+body[data-display-mode='phone'] .site-nav__actions {
+  width: 100%;
+  justify-content: flex-start !important;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='phone'] .site-nav__actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+body[data-display-mode='tablet'] .site-nav__cart-actions,
+body[data-display-mode='phone'] .site-nav__cart-actions,
+body[data-display-mode='tablet'] .discount-field,
+body[data-display-mode='phone'] .discount-field,
+body[data-display-mode='tablet'] .display-mode-toggle,
+body[data-display-mode='phone'] .display-mode-toggle {
+  margin-left: 0 !important;
+}
+
+body[data-display-mode='tablet'] .site-nav__cart-actions,
+body[data-display-mode='phone'] .site-nav__cart-actions {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+body[data-display-mode='phone'] .site-nav__cart-actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+body[data-display-mode='phone'] .site-nav__cart-actions .btn-secondary,
+body[data-display-mode='phone'] .site-nav__actions .btn-primary,
+body[data-display-mode='phone'] .site-nav__actions .btn-secondary {
+  width: 100%;
+}
+
+body[data-display-mode='tablet'] .site-nav__tree,
+body[data-display-mode='phone'] .site-nav__tree {
+  width: 100%;
+  flex: 1 1 100%;
+}
+
+body[data-display-mode='tablet'] .main-layout,
+body[data-display-mode='phone'] .main-layout {
+  flex-direction: column;
+}
+
+body[data-display-mode='tablet'] .gutter.gutter-horizontal,
+body[data-display-mode='phone'] .gutter.gutter-horizontal {
+  display: none !important;
+}
+
+body[data-display-mode='tablet'] #catalogue-panel,
+body[data-display-mode='tablet'] #quote-panel,
+body[data-display-mode='phone'] #catalogue-panel,
+body[data-display-mode='phone'] #quote-panel {
+  width: 100%;
+  padding: 1.5rem;
+}
+
+body[data-display-mode='phone'] #product-grid {
+  grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
+}
+
+body[data-display-mode='tablet'] #product-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+}
+
+body[data-display-mode='phone'] #quote-panel {
+  margin-top: 1.5rem;
+}
+
+body[data-display-mode='phone'] .quote-row {
+  padding: 1.25rem;
+}
+
+body[data-display-mode='phone'] .footer-meta {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+body[data-display-mode='tablet'] .catalogue-header .flex[class*='xl:flex-row'],
+body[data-display-mode='phone'] .catalogue-header .flex[class*='xl:flex-row'] {
+  flex-direction: column !important;
+  align-items: stretch !important;
+  justify-content: flex-start !important;
+  gap: 1rem;
+}
+
+body[data-display-mode='tablet'] .catalogue-header .flex[class*='sm:flex-row'],
+body[data-display-mode='phone'] .catalogue-header .flex[class*='sm:flex-row'] {
+  flex-direction: column !important;
+  align-items: stretch !important;
+  gap: 0.75rem !important;
+}
+
 @media (max-width: 1024px) {
   .main-layout {
     flex-direction: column;
@@ -1641,25 +1854,16 @@ textarea {
     justify-content: flex-start;
   }
 
-  .site-nav__save-group {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .save-name-field {
-    width: 100%;
-  }
-
-  .save-name-field input {
-    width: 100%;
-  }
-
   .site-nav__identity,
   .site-nav__cart-actions,
   .site-nav__tree {
     width: 100%;
     flex: 1 1 100%;
     margin-left: 0;
+  }
+
+  .site-nav__cart-actions {
+    justify-content: flex-start;
   }
 
   #main-layout {
@@ -1683,15 +1887,10 @@ textarea {
     width: 100%;
   }
 
-  .site-nav__save-group {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
-  }
-
   .site-nav__cart-actions {
     flex-direction: column;
     align-items: stretch;
+    gap: 0.5rem;
   }
 
   .site-nav__cart-actions .btn-secondary {

--- a/index.html
+++ b/index.html
@@ -85,81 +85,85 @@
               <span class="sr-only">Modifier</span>
             </button>
           </div>
-          <div class="site-nav__save-group">
-            <label for="save-name" class="save-name-field">
-              <span>Proposition</span>
-              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
-            </label>
-            <div class="site-nav__cart-actions">
-              <button
-                id="save-cart"
-                type="button"
-                class="btn-secondary btn-icon"
-                data-tooltip="Sauvegarder le panier"
-                aria-label="Sauvegarder le panier"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M9 3h6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M9 13h6v6H9z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Sauvegarder</span>
-              </button>
-              <button
-                id="restore-cart"
-                type="button"
-                class="btn-secondary btn-icon"
-                data-tooltip="Restaurer une sauvegarde"
-                aria-label="Restaurer une sauvegarde"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M4 4v6h6M20 20v-6h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Restaurer</span>
-              </button>
-              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-            </div>
+          <div class="site-nav__cart-actions">
+            <button
+              id="save-cart"
+              type="button"
+              class="btn-secondary btn-icon"
+              data-tooltip="Sauvegarder le panier"
+              aria-label="Sauvegarder le panier"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                <path
+                  d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M9 3h6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M9 13h6v6H9z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+              </svg>
+              <span class="sr-only">Sauvegarder</span>
+            </button>
+            <button
+              id="restore-cart"
+              type="button"
+              class="btn-secondary btn-icon"
+              data-tooltip="Restaurer une sauvegarde"
+              aria-label="Restaurer une sauvegarde"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                <path
+                  d="M4 4v6h6M20 20v-6h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+              </svg>
+              <span class="sr-only">Restaurer</span>
+            </button>
+            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
           </div>
           <div class="discount-field" aria-live="polite">
             <span>Remise</span>
             <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
           </div>
+          <button
+            id="display-mode-toggle"
+            type="button"
+            class="btn-secondary btn-icon display-mode-toggle"
+            data-tooltip="Changer le mode d'affichage"
+            aria-label="Mode d'affichage automatique"
+            data-mode="desktop"
+          >
+            <span class="display-mode-toggle__icon" aria-hidden="true"></span>
+          </button>
           <button
             id="generate-pdf"
             class="btn-primary btn-icon"
@@ -209,25 +213,11 @@
             <span class="sr-only">Passer commande</span>
           </button>
           <div class="site-nav__tree">
-            <label
-              for="catalogue-tree"
-              class="site-nav__tree-label icon-label"
-              data-tooltip="Sélectionner une catégorie"
-              aria-label="Sélectionner une catégorie"
+            <select
+              id="catalogue-tree"
+              class="site-nav__tree-select"
+              aria-label="Sélectionner une catégorie ou un article"
             >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 6h16M4 12h16M4 18h16"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sélectionner une catégorie</span>
-            </label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
               <option value="">Sélectionner une catégorie ou un article</option>
             </select>
           </div>
@@ -599,6 +589,40 @@
       </div>
     </div>
 
+    <div
+      id="save-cart-modal"
+      class="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="save-cart-modal-title"
+      data-open="false"
+    >
+      <div class="modal-card save-cart-modal-card">
+        <form id="save-cart-form" class="modal-body save-cart-modal-body">
+          <h2 id="save-cart-modal-title" class="save-cart-modal-title">Nommer votre sauvegarde</h2>
+          <p class="save-cart-modal-intro">
+            Indiquez un nom pour retrouver facilement ce panier plus tard.
+          </p>
+          <label class="save-cart-modal-field">
+            <span>Nom du panier</span>
+            <input
+              id="save-cart-name"
+              name="saveName"
+              type="text"
+              maxlength="80"
+              required
+              placeholder="Ex. Projet magasin"
+            />
+          </label>
+          <p id="save-cart-feedback" class="save-cart-modal-feedback" role="alert"></p>
+          <div class="modal-actions save-cart-modal-actions">
+            <button id="save-cart-cancel" type="button" class="btn-secondary">Annuler</button>
+            <button type="submit" class="btn-primary">Sauvegarder</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
     <section id="client-form-placeholder" class="client-form-placeholder" aria-live="polite" data-open="false">
       <div class="client-form-placeholder__content">
         <h2>Formulaire client</h2>
@@ -618,6 +642,13 @@
         <button id="webhook-panel-close" type="button" class="webhook-panel__close" aria-label="Fermer">×</button>
       </div>
       <div id="webhook-panel-content" class="webhook-panel__content"></div>
+    </div>
+
+    <div id="global-loading" class="loading-overlay" hidden aria-live="polite" aria-busy="true">
+      <div class="loading-overlay__content">
+        <span class="loading-overlay__icon" aria-hidden="true">⌛</span>
+        <p id="global-loading-text" class="loading-overlay__text">Préparation en cours...</p>
+      </div>
     </div>
 
     <footer class="site-footer">


### PR DESCRIPTION
## Résumé
- réduit et simplifie la sélection du catalogue dans la barre de navigation et ajoute un bouton pour changer de mode d'affichage
- introduit une modale de sauvegarde avec saisie du nom du panier et une fenêtre de chargement pour l'envoi des commandes
- met en place les modes bureau, tablette et téléphone avec bascule manuelle et adaptations du menu, de la recherche, du panier et du pied de page
- remplace l'activation du mode debug par un double clic sur le logo

## Tests
- non effectués (application front statique)


------
https://chatgpt.com/codex/tasks/task_b_68e62ae4a5408329b8acd3e77456011e