### PR TITLE
Ajouter les modes d'affichage et la modale de sauvegarde

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -238,54 +238,14 @@ textarea {
   gap: 0.75rem;
 }
 
-.save-name-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 63, 96, 0.15);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.save-name-field input {
-  border: 1px solid rgba(25, 63, 96, 0.2);
-  border-radius: 0.6rem;
-  padding: 0.45rem 0.6rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--color-secondary);
-  background: #fff;
-  min-width: 12rem;
-}
-
-.save-name-field input:focus {
-  outline: none;
-  border-color: var(--color-secondary);
-  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
-}
-
 .site-nav__tree {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  min-width: 10rem;
-  flex: 0 1 12rem;
-  width: min(100%, 14rem);
+  gap: 0.25rem;
+  min-width: 8.5rem;
+  flex: 0 1 10rem;
+  width: min(100%, 11rem);
   margin-left: auto;
-}
-
-.site-nav__tree-label {
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
 }
 
 .site-nav__tree-select {
@@ -294,10 +254,27 @@ textarea {
   border-radius: 0.6rem;
   border: 1px solid rgba(25, 63, 96, 0.15);
   background: rgba(255, 255, 255, 0.9);
-  padding: 0.55rem 0.75rem;
-  font-size: 0.85rem;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.8rem;
+  min-height: 2.35rem;
   color: var(--color-muted-strong);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.display-mode-toggle {
+  position: relative;
+}
+
+.display-mode-toggle__icon {
+  display: none;
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.display-mode-toggle[data-mode='desktop'] .display-mode-toggle__icon[data-icon='desktop'],
+.display-mode-toggle[data-mode='tablet'] .display-mode-toggle__icon[data-icon='tablet'],
+.display-mode-toggle[data-mode='phone'] .display-mode-toggle__icon[data-icon='phone'] {
+  display: block;
 }
 
 .webhook-mode-badge {
@@ -670,30 +647,6 @@ textarea {
 .icon {
   width: 1.35rem;
   height: 1.35rem;
-}
-
-.icon-label {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.65rem;
-  height: 2.65rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 63, 96, 0.2);
-  color: var(--color-secondary);
-  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
-  cursor: pointer;
-}
-
-.icon-label:hover,
-.icon-label:focus-visible {
-  background: rgba(25, 63, 96, 0.08);
-  border-color: rgba(25, 63, 96, 0.3);
-}
-
-.site-nav__tree-label.icon-label {
-  align-self: flex-start;
 }
 
 .btn-secondary {
@@ -1073,6 +1026,59 @@ textarea {
   display: flex;
   justify-content: flex-end;
   gap: 0.75rem;
+}
+
+.save-name-modal-card {
+  max-width: 28rem;
+}
+
+.save-name-modal-body {
+  gap: 1.5rem;
+}
+
+.save-name-modal-title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.save-name-modal-text {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--color-muted-strong);
+}
+
+.save-name-modal-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.save-name-modal-field span {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+.save-name-modal-field input {
+  border: 1px solid rgba(25, 63, 96, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.save-name-modal-field input:focus {
+  outline: none;
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
+}
+
+.save-name-modal-actions {
+  justify-content: flex-end;
 }
 
 #siret-error-modal .modal-card {
@@ -1646,14 +1652,6 @@ textarea {
     justify-content: space-between;
   }
 
-  .save-name-field {
-    width: 100%;
-  }
-
-  .save-name-field input {
-    width: 100%;
-  }
-
   .site-nav__identity,
   .site-nav__cart-actions,
   .site-nav__tree {
@@ -1729,6 +1727,235 @@ textarea {
     flex: 1 1 100%;
   }
 }
+
+body[data-display-mode='desktop'] .site-nav__inner {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='desktop'] .site-nav__actions {
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='desktop'] .site-nav__save-group {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='desktop'] .site-nav__cart-actions {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='desktop'] .site-nav__cart-actions .btn-secondary,
+body[data-display-mode='desktop'] .display-mode-toggle {
+  width: auto;
+}
+
+body[data-display-mode='desktop'] .main-layout {
+  flex-direction: row;
+  gap: 1.5rem;
+}
+
+body[data-display-mode='desktop'] .footer-inner {
+  align-items: flex-start;
+  text-align: left;
+}
+
+body[data-display-mode='desktop'] .footer-meta {
+  flex-direction: row;
+  align-items: flex-start;
+}
+
+body[data-display-mode='tablet'] .site-nav__inner {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='tablet'] .site-nav__actions {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+body[data-display-mode='tablet'] .site-nav__save-group {
+  width: 100%;
+  justify-content: space-between;
+}
+
+body[data-display-mode='tablet'] .site-nav__cart-actions {
+  flex: 1;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+body[data-display-mode='tablet'] .display-mode-toggle {
+  margin-left: auto;
+}
+
+body[data-display-mode='tablet'] .site-nav__tree {
+  width: 100%;
+  flex: 1 1 100%;
+  margin-left: 0;
+}
+
+body[data-display-mode='tablet'] .main-layout {
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+body[data-display-mode='tablet'] #catalogue-panel,
+body[data-display-mode='tablet'] #quote-panel {
+  padding: 1.75rem;
+}
+
+body[data-display-mode='tablet'] .footer-inner {
+  align-items: stretch;
+}
+
+body[data-display-mode='tablet'] .footer-meta {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+body[data-display-mode='phone'] .site-nav__inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+body[data-display-mode='phone'] .site-nav__actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+body[data-display-mode='phone'] .site-nav__save-group {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+body[data-display-mode='phone'] .site-nav__cart-actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+body[data-display-mode='phone'] .site-nav__cart-actions .btn-secondary,
+body[data-display-mode='phone'] .display-mode-toggle,
+body[data-display-mode='phone'] .site-nav__actions .btn-primary {
+  width: 100%;
+}
+
+body[data-display-mode='phone'] .site-nav__tree {
+  width: 100%;
+  flex: 1 1 100%;
+  margin-left: 0;
+}
+
+body[data-display-mode='phone'] .main-layout {
+  flex-direction: column;
+  gap: 1rem;
+}
+
+body[data-display-mode='phone'] #catalogue-panel,
+body[data-display-mode='phone'] #quote-panel {
+  padding: 1.5rem;
+}
+
+body[data-display-mode='phone'] .product-card {
+  padding: 1.25rem;
+}
+
+body[data-display-mode='phone'] .product-card .product-actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+body[data-display-mode='phone'] .product-card .product-actions .flex {
+  width: 100%;
+}
+
+body[data-display-mode='phone'] .product-card .product-actions button {
+  width: 100%;
+}
+
+body[data-display-mode='phone'] .quote-row {
+  padding: 0.75rem;
+}
+
+body[data-display-mode='phone'] .footer-inner {
+  align-items: center;
+  text-align: center;
+}
+
+body[data-display-mode='phone'] .footer-meta {
+  flex-direction: column;
+  align-items: center;
+}
+
+.global-loader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(2px);
+  z-index: 80;
+  padding: 1.5rem;
+}
+
+.global-loader__content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 2rem 2.5rem;
+  border-radius: 1.5rem;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 30px 70px -35px rgba(25, 63, 96, 0.65);
+}
+
+.global-loader__spinner {
+  display: inline-flex;
+  width: 3.25rem;
+  height: 3.25rem;
+  color: var(--color-primary);
+}
+
+.global-loader__spinner svg {
+  width: 100%;
+  height: 100%;
+  animation: loader-hourglass 1.4s ease-in-out infinite;
+}
+
+.global-loader__message {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+  text-align: center;
+}
+
+@keyframes loader-hourglass {
+  0%,
+  100% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(180deg);
+  }
+}
+
 .site-body a {
   color: var(--color-primary);
   text-decoration: none;

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <script src="https://unpkg.com/split.js/dist/split.min.js" defer></script>
     <script src="js/app.js" type="module" defer></script>
   </head>
-  <body class="site-body min-h-screen">
+  <body class="site-body min-h-screen" data-display-mode="desktop">
     <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
@@ -86,10 +86,6 @@
             </button>
           </div>
           <div class="site-nav__save-group">
-            <label for="save-name" class="save-name-field">
-              <span>Proposition</span>
-              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
-            </label>
             <div class="site-nav__cart-actions">
               <button
                 id="save-cart"
@@ -155,6 +151,34 @@
               </button>
               <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
             </div>
+            <button
+              id="display-mode-toggle"
+              type="button"
+              class="btn-secondary btn-icon display-mode-toggle"
+              data-tooltip="Changer le mode d'affichage"
+              aria-label="Changer le mode d'affichage"
+              data-mode="desktop"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="display-mode-toggle__icon" data-icon="desktop">
+                <path
+                  d="M4 5a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2h-5v2h3a1 1 0 1 1 0 2H8a1 1 0 1 1 0-2h3v-2H6a2 2 0 0 1-2-2Z"
+                  fill="currentColor"
+                />
+              </svg>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="display-mode-toggle__icon" data-icon="tablet">
+                <path
+                  d="M7 3h10a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm5 15.5a1.25 1.25 0 1 0 0-2.5 1.25 1.25 0 0 0 0 2.5Z"
+                  fill="currentColor"
+                />
+              </svg>
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="display-mode-toggle__icon" data-icon="phone">
+                <path
+                  d="M9 2.75A1.75 1.75 0 0 1 10.75 1h2.5A1.75 1.75 0 0 1 15 2.75v18.5A1.75 1.75 0 0 1 13.25 23h-2.5A1.75 1.75 0 0 1 9 21.25Zm3 15.75a1 1 0 1 0 0 2 1 1 0 0 0 0-2Z"
+                  fill="currentColor"
+                />
+              </svg>
+              <span class="sr-only">Modifier le mode d'affichage</span>
+            </button>
           </div>
           <div class="discount-field" aria-live="polite">
             <span>Remise</span>
@@ -209,25 +233,8 @@
             <span class="sr-only">Passer commande</span>
           </button>
           <div class="site-nav__tree">
-            <label
-              for="catalogue-tree"
-              class="site-nav__tree-label icon-label"
-              data-tooltip="Sélectionner une catégorie"
-              aria-label="Sélectionner une catégorie"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 6h16M4 12h16M4 18h16"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sélectionner une catégorie</span>
-            </label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
+            <label for="catalogue-tree" class="sr-only">Sélectionner une catégorie</label>
+            <select id="catalogue-tree" class="site-nav__tree-select" aria-label="Sélectionner une catégorie">
               <option value="">Sélectionner une catégorie ou un article</option>
             </select>
           </div>
@@ -549,6 +556,38 @@
     </div>
 
     <div
+      id="save-name-modal"
+      class="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="save-name-modal-title"
+      data-open="false"
+    >
+      <div class="modal-card save-name-modal-card">
+        <form id="save-name-form" class="modal-body save-name-modal-body">
+          <h2 id="save-name-modal-title" class="save-name-modal-title">Nommer votre panier</h2>
+          <p class="save-name-modal-text">
+            Donnez un nom à votre panier pour retrouver facilement vos sauvegardes ultérieures.
+          </p>
+          <label class="save-name-modal-field">
+            <span>Nom du panier</span>
+            <input
+              id="save-name-field"
+              type="text"
+              maxlength="80"
+              required
+              placeholder="Ex. Projet magasin"
+            />
+          </label>
+          <div class="modal-actions save-name-modal-actions">
+            <button type="button" class="btn-secondary" id="save-name-cancel">Annuler</button>
+            <button type="submit" class="btn-primary">Sauvegarder</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div
       id="order-confirmation-modal"
       class="modal-backdrop"
       role="dialog"
@@ -652,5 +691,18 @@
         <p class="text-xs text-slate-500">© <span id="current-year"></span> ID GROUP — Tous droits réservés.</p>
       </div>
     </footer>
+
+    <div id="global-loader" class="global-loader" role="status" aria-live="assertive" hidden>
+      <div class="global-loader__content">
+        <span class="global-loader__spinner" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M8 2.5h8a1.5 1.5 0 0 1 1.5 1.5v2a4.5 4.5 0 0 1-1.318 3.182L13 12l3.182 2.818A4.5 4.5 0 0 1 17.5 18.182V20a1.5 1.5 0 0 1-1.5 1.5H8A1.5 1.5 0 0 1 6.5 20v-1.818a4.5 4.5 0 0 1 1.318-3.364L11 12 7.818 9.182A4.5 4.5 0 0 1 6.5 5.909V4A1.5 1.5 0 0 1 8 2.5Z" />
+            <path d="M9 6h6" />
+            <path d="M9 18h6" />
+          </svg>
+        </span>
+        <p id="global-loader-message" class="global-loader__message">Préparation du devis en PDF…</p>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- compacté la sélection de catégorie dans la barre de navigation et retiré l’icône décorative
- remplacé le champ « Proposition » par une modale de nomination lors de la sauvegarde et ajouté un sablier lors de l’envoi de commande
- introduit un sélecteur bureau/tablette/téléphone avec détection automatique et styles adaptés pour chaque mode
- activé le mode debug par double-clic sur le logo uniquement

## Testing
- Non testé (application front statique sans suite automatique)


------
https://chatgpt.com/codex/tasks/task_b_68e62ae4a5408329b8acd3e77456011e