### PR TITLE
feat: modes d'affichage responsives et sauvegarde modernisée

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -238,52 +238,20 @@ textarea {
   gap: 0.75rem;
 }
 
-.save-name-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 63, 96, 0.15);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.save-name-field input {
-  border: 1px solid rgba(25, 63, 96, 0.2);
-  border-radius: 0.6rem;
-  padding: 0.45rem 0.6rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--color-secondary);
-  background: #fff;
-  min-width: 12rem;
-}
-
-.save-name-field input:focus {
-  outline: none;
-  border-color: var(--color-secondary);
-  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
-}
-
 .site-nav__tree {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  min-width: 10rem;
-  flex: 0 1 12rem;
-  width: min(100%, 14rem);
+  gap: 0.25rem;
+  min-width: 8rem;
+  flex: 0 1 11rem;
+  width: min(100%, 12rem);
   margin-left: auto;
 }
 
 .site-nav__tree-label {
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
+  font-size: 0.6rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
@@ -294,10 +262,52 @@ textarea {
   border-radius: 0.6rem;
   border: 1px solid rgba(25, 63, 96, 0.15);
   background: rgba(255, 255, 255, 0.9);
-  padding: 0.55rem 0.75rem;
-  font-size: 0.85rem;
+  padding: 0.5rem 0.65rem;
+  font-size: 0.8rem;
   color: var(--color-muted-strong);
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.display-mode-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.85rem;
+  min-height: 2.85rem;
+  border-radius: 0.85rem;
+}
+
+.display-mode-toggle__icon {
+  display: none;
+}
+
+.display-mode-toggle__icon--desktop {
+  display: block;
+}
+
+body[data-display-mode='desktop'] .display-mode-toggle__icon {
+  display: none;
+}
+
+body[data-display-mode='desktop'] .display-mode-toggle__icon--desktop {
+  display: block;
+}
+
+body[data-display-mode='tablet'] .display-mode-toggle__icon {
+  display: none;
+}
+
+body[data-display-mode='tablet'] .display-mode-toggle__icon--tablet {
+  display: block;
+}
+
+body[data-display-mode='phone'] .display-mode-toggle__icon {
+  display: none;
+}
+
+body[data-display-mode='phone'] .display-mode-toggle__icon--phone {
+  display: block;
 }
 
 .webhook-mode-badge {
@@ -1134,6 +1144,55 @@ textarea {
   line-height: 1.6;
 }
 
+.save-cart-modal-card {
+  max-width: 28rem;
+}
+
+.save-cart-modal-body {
+  gap: 1.1rem;
+}
+
+.save-cart-modal-title {
+  font-size: 1.3rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.save-cart-modal-intro {
+  font-size: 0.95rem;
+  color: var(--color-muted-strong);
+  line-height: 1.6;
+}
+
+.save-cart-modal-field {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--color-muted);
+}
+
+#save-cart-modal-input {
+  border: 1px solid rgba(25, 63, 96, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+  background: #fff;
+}
+
+#save-cart-modal-input:focus {
+  outline: none;
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.18);
+}
+
+.save-cart-modal-actions {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
 .order-modal-grid {
   display: grid;
   gap: 0.85rem;
@@ -1729,6 +1788,132 @@ textarea {
     flex: 1 1 100%;
   }
 }
+
+body[data-display-mode='tablet'] .main-layout,
+body[data-display-mode='phone'] .main-layout {
+  flex-direction: column;
+}
+
+body[data-display-mode='tablet'] .gutter.gutter-horizontal,
+body[data-display-mode='phone'] .gutter.gutter-horizontal {
+  display: none;
+}
+
+body[data-display-mode='tablet'] .site-nav__inner,
+body[data-display-mode='phone'] .site-nav__inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+body[data-display-mode='tablet'] .site-nav__actions,
+body[data-display-mode='phone'] .site-nav__actions {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+body[data-display-mode='tablet'] .site-nav__save-group,
+body[data-display-mode='phone'] .site-nav__save-group {
+  width: 100%;
+  justify-content: flex-start;
+}
+
+body[data-display-mode='tablet'] .site-nav__cart-actions {
+  gap: 0.6rem;
+}
+
+body[data-display-mode='tablet'] .site-nav__tree {
+  width: 100%;
+  flex: 1 1 100%;
+  margin-left: 0;
+}
+
+body[data-display-mode='tablet'] .display-mode-toggle {
+  margin-left: auto;
+}
+
+body[data-display-mode='phone'] .site-nav__actions {
+  flex-direction: column;
+  gap: 0.65rem;
+  align-items: stretch;
+}
+
+body[data-display-mode='phone'] .site-nav__save-group {
+  align-items: stretch;
+  gap: 0.65rem;
+}
+
+body[data-display-mode='phone'] .site-nav__cart-actions {
+  flex-direction: column;
+  align-items: stretch;
+}
+
+body[data-display-mode='phone'] .site-nav__cart-actions .btn-secondary {
+  width: 100%;
+}
+
+body[data-display-mode='phone'] .display-mode-toggle {
+  align-self: flex-end;
+}
+
+body[data-display-mode='phone'] .site-nav__tree {
+  width: 100%;
+  flex: 1 1 100%;
+}
+
+body[data-display-mode='phone'] #search {
+  font-size: 1rem;
+  padding: 0.75rem 1rem;
+}
+
+body[data-display-mode='tablet'] #product-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
+}
+
+body[data-display-mode='phone'] #product-grid {
+  grid-template-columns: 1fr !important;
+}
+
+body[data-display-mode='tablet'] #catalogue-panel,
+body[data-display-mode='tablet'] #quote-panel,
+body[data-display-mode='phone'] #catalogue-panel,
+body[data-display-mode='phone'] #quote-panel {
+  padding: 1.75rem !important;
+}
+
+body[data-display-mode='phone'] .quote-summary-panel,
+body[data-display-mode='tablet'] .quote-summary-panel {
+  position: relative;
+  top: auto;
+}
+
+body[data-display-mode='phone'] .quote-summary-panel {
+  margin-top: 1rem;
+}
+
+body[data-display-mode='phone'] .quote-summary-panel dl {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+body[data-display-mode='phone'] .quote-summary-panel dt,
+body[data-display-mode='phone'] .quote-summary-panel dd {
+  font-size: 0.85rem;
+}
+
+body[data-display-mode='tablet'] .site-footer .footer-inner,
+body[data-display-mode='phone'] .site-footer .footer-inner {
+  padding: 2.5rem 1.5rem;
+  align-items: flex-start;
+}
+
+body[data-display-mode='phone'] .footer-meta {
+  flex-direction: column;
+  gap: 1rem;
+}
+
+body[data-display-mode='phone'] .site-footer p {
+  text-align: left;
+}
 .site-body a {
   color: var(--color-primary);
   text-decoration: none;
@@ -1743,6 +1928,92 @@ textarea {
 
 body[data-debug-mode='true'] {
   cursor: crosshair;
+}
+
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: rgba(15, 30, 45, 0.55);
+  backdrop-filter: blur(2px);
+  z-index: 65;
+  padding: 1.5rem;
+}
+
+.loading-overlay[data-open='true'] {
+  display: flex;
+}
+
+.loading-overlay__content {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.25rem;
+  padding: 2rem 2.5rem;
+  box-shadow: 0 26px 60px -32px rgba(25, 63, 96, 0.45);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  color: var(--color-secondary);
+  text-align: center;
+  max-width: 24rem;
+  width: 100%;
+}
+
+.loading-overlay__icon {
+  width: 3rem;
+  height: 3rem;
+  color: var(--color-secondary);
+  transform-origin: center;
+  animation: hourglass-spin 2s infinite linear;
+}
+
+.loading-overlay__hourglass {
+  stroke: currentColor;
+}
+
+.loading-overlay__sand {
+  fill: currentColor;
+  animation: hourglass-sand 2s infinite ease-in-out;
+  transform-origin: center;
+}
+
+.loading-overlay__text {
+  font-size: 0.95rem;
+  line-height: 1.6;
+  font-weight: 600;
+}
+
+@keyframes hourglass-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  50% {
+    transform: rotate(180deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes hourglass-sand {
+  0% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+  45% {
+    transform: scaleY(0.2);
+    opacity: 0.6;
+  }
+  55% {
+    transform: scaleY(0.2);
+    opacity: 0.4;
+  }
+  100% {
+    transform: scaleY(1);
+    opacity: 1;
+  }
 }
 
 .debug-panel {

--- a/index.html
+++ b/index.html
@@ -86,10 +86,6 @@
             </button>
           </div>
           <div class="site-nav__save-group">
-            <label for="save-name" class="save-name-field">
-              <span>Proposition</span>
-              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
-            </label>
             <div class="site-nav__cart-actions">
               <button
                 id="save-cart"
@@ -208,26 +204,37 @@
             </svg>
             <span class="sr-only">Passer commande</span>
           </button>
+          <button
+            id="display-mode-toggle"
+            type="button"
+            class="btn-secondary btn-icon display-mode-toggle"
+            data-tooltip="Mode d'affichage : Bureau"
+            aria-label="Changer le mode d'affichage"
+            aria-describedby="display-mode-toggle-label"
+          >
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon display-mode-toggle__icon display-mode-toggle__icon--desktop">
+              <path
+                d="M4 5.5a1.5 1.5 0 0 1 1.5-1.5h13a1.5 1.5 0 0 1 1.5 1.5v9a1.5 1.5 0 0 1-1.5 1.5H13v2h2v1h-6v-1h2v-2H5.5A1.5 1.5 0 0 1 4 14.5Z"
+                fill="currentColor"
+              />
+            </svg>
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon display-mode-toggle__icon display-mode-toggle__icon--tablet">
+              <path
+                d="M7 3h10a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Zm5 16a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                fill="currentColor"
+              />
+            </svg>
+            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon display-mode-toggle__icon display-mode-toggle__icon--phone">
+              <path
+                d="M9 2h6a2 2 0 0 1 2 2v16a2 2 0 0 1-2 2H9a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Zm3 18a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z"
+                fill="currentColor"
+              />
+            </svg>
+            <span id="display-mode-toggle-label" class="sr-only">Mode bureau</span>
+          </button>
           <div class="site-nav__tree">
-            <label
-              for="catalogue-tree"
-              class="site-nav__tree-label icon-label"
-              data-tooltip="Sélectionner une catégorie"
-              aria-label="Sélectionner une catégorie"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 6h16M4 12h16M4 18h16"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sélectionner une catégorie</span>
-            </label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
+            <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
+            <select id="catalogue-tree" class="site-nav__tree-select" aria-label="Sélectionner une catégorie">
               <option value="">Sélectionner une catégorie ou un article</option>
             </select>
           </div>
@@ -596,6 +603,54 @@
             <button type="submit" class="btn-primary">Confirmer l'envoi</button>
           </div>
         </form>
+      </div>
+    </div>
+    <div
+      id="save-cart-modal"
+      class="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="save-cart-modal-title"
+      data-open="false"
+    >
+      <div class="modal-card save-cart-modal-card">
+        <form id="save-cart-form" class="modal-body save-cart-modal-body">
+          <h2 id="save-cart-modal-title" class="save-cart-modal-title">Nommer votre panier</h2>
+          <p class="save-cart-modal-intro">Indiquez un nom pour retrouver facilement cette sauvegarde.</p>
+          <label class="save-cart-modal-field" for="save-cart-modal-input">Nom du panier</label>
+          <input
+            id="save-cart-modal-input"
+            type="text"
+            maxlength="80"
+            placeholder="Ex. Projet magasin"
+            autocomplete="off"
+            required
+          />
+          <div class="modal-actions save-cart-modal-actions">
+            <button id="save-cart-cancel" type="button" class="btn-secondary">Annuler</button>
+            <button type="submit" class="btn-primary">Sauvegarder</button>
+          </div>
+        </form>
+      </div>
+    </div>
+    <div id="order-loading-overlay" class="loading-overlay" role="status" aria-live="polite" data-open="false">
+      <div class="loading-overlay__content">
+        <svg class="loading-overlay__icon" viewBox="0 0 64 64" aria-hidden="true">
+          <path
+            class="loading-overlay__hourglass"
+            d="M18 8h28a2 2 0 0 1 2 2v4c0 8.8-8 14.4-11 16 3 1.6 11 7.2 11 16v4a2 2 0 0 1-2 2H18a2 2 0 0 1-2-2v-4c0-8.8 8-14.4 11-16-3-1.6-11-7.2-11-16v-4a2 2 0 0 1 2-2Z"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="4"
+            stroke-linejoin="round"
+          />
+          <path
+            class="loading-overlay__sand"
+            d="M23 14h18c0 6-6 10-9 11-3-1-9-5-9-11Zm0 36h18c0-6-6-10-9-11-3 1-9 5-9 11Z"
+            fill="currentColor"
+          />
+        </svg>
+        <p class="loading-overlay__text">Préparation du devis en cours...</p>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- remplacement du champ "Proposition" par une modale dédiée à la sauvegarde du panier et ajout d'un sablier pendant l'envoi de commande
- ajout d'un sélecteur de mode d'affichage (bureau, tablette, téléphone) avec détection automatique et styles associés
- refonte du JavaScript pour piloter les nouveaux modes, la modale de sauvegarde et le chargement lors de l'envoi de la commande

## Testing
- non applicable

------
https://chatgpt.com/codex/tasks/task_b_68e62ae4a5408329b8acd3e77456011e