### PR TITLE
Ajout du nouveau sélecteur de mode d’affichage et des modales panier

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -231,59 +231,20 @@ textarea {
   gap: 0.75rem;
 }
 
-.site-nav__save-group {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.save-name-field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 63, 96, 0.15);
-  font-size: 0.65rem;
-  font-weight: 600;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--color-muted);
-}
-
-.save-name-field input {
-  border: 1px solid rgba(25, 63, 96, 0.2);
-  border-radius: 0.6rem;
-  padding: 0.45rem 0.6rem;
-  font-size: 0.85rem;
-  font-weight: 500;
-  color: var(--color-secondary);
-  background: #fff;
-  min-width: 12rem;
-}
-
-.save-name-field input:focus {
-  outline: none;
-  border-color: var(--color-secondary);
-  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
-}
-
 .site-nav__tree {
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
-  min-width: 10rem;
-  flex: 0 1 12rem;
-  width: min(100%, 14rem);
+  gap: 0.25rem;
+  min-width: 8rem;
+  flex: 0 1 10rem;
+  width: min(100%, 11rem);
   margin-left: auto;
 }
 
 .site-nav__tree-label {
-  font-size: 0.65rem;
+  font-size: 0.7rem;
   font-weight: 600;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--color-muted);
 }
@@ -412,6 +373,52 @@ textarea {
 .site-nav__cart-actions .btn-secondary {
   white-space: nowrap;
 }
+
+.viewport-toggle {
+  display: flex;
+  align-items: center;
+}
+
+.viewport-toggle__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.75rem;
+  border-radius: 0.8rem;
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  background: rgba(255, 255, 255, 0.92);
+  color: var(--color-secondary);
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.viewport-toggle__button:hover,
+.viewport-toggle__button:focus-visible {
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
+  outline: none;
+}
+
+.viewport-toggle__icon {
+  width: 1.5rem;
+  height: 1.5rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+}
+
+.viewport-toggle__icon-stand {
+  fill: currentColor;
+  stroke: none;
+}
+
+.viewport-toggle__label {
+  white-space: nowrap;
+}
+
 
 .webhook-panel {
   position: fixed;
@@ -1075,6 +1082,60 @@ textarea {
   gap: 0.75rem;
 }
 
+.form-error {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.save-cart-modal {
+  max-width: 28rem;
+}
+
+.save-cart-modal__body {
+  gap: 0.75rem;
+}
+
+.save-cart-modal__title {
+  font-size: 1.35rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.save-cart-modal__subtitle {
+  font-size: 0.9rem;
+  color: var(--color-muted-strong);
+}
+
+.save-cart-modal__label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  font-weight: 600;
+  color: var(--color-muted);
+}
+
+.save-cart-modal__input {
+  border: 1px solid rgba(25, 63, 96, 0.2);
+  border-radius: 0.75rem;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: var(--color-secondary);
+  background: rgba(255, 255, 255, 0.96);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.save-cart-modal__input:focus {
+  outline: none;
+  border-color: var(--color-secondary);
+  box-shadow: 0 0 0 3px rgba(25, 63, 96, 0.15);
+}
+
+.save-cart-modal__actions {
+  justify-content: space-between;
+}
+
 #siret-error-modal .modal-card {
   max-width: 32rem;
 }
@@ -1103,6 +1164,99 @@ textarea {
 .siret-modal-actions {
   flex-wrap: wrap;
   justify-content: flex-start;
+}
+
+.loader-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(25, 63, 96, 0.45);
+  backdrop-filter: blur(2px);
+  z-index: 70;
+}
+
+.loader-backdrop[hidden] {
+  display: none !important;
+}
+
+.loader-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1.75rem 2.25rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.95);
+  box-shadow: 0 25px 55px -24px rgba(25, 63, 96, 0.6);
+  text-align: center;
+}
+
+.loader-hourglass {
+  position: relative;
+  width: 2.4rem;
+  height: 2.4rem;
+  color: var(--color-secondary);
+}
+
+.loader-hourglass::before,
+.loader-hourglass::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  width: 0;
+  height: 0;
+  border-left: 1.2rem solid transparent;
+  border-right: 1.2rem solid transparent;
+}
+
+.loader-hourglass::before {
+  top: 0;
+  border-bottom: 1.2rem solid currentColor;
+  animation: hourglass-top 1.4s infinite ease-in-out;
+}
+
+.loader-hourglass::after {
+  bottom: 0;
+  border-top: 1.2rem solid currentColor;
+  animation: hourglass-bottom 1.4s infinite ease-in-out;
+}
+
+#global-loader-message {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+@keyframes hourglass-top {
+  0% {
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+  50% {
+    transform: translate(-50%, 0.45rem);
+    opacity: 0.2;
+  }
+  100% {
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+}
+
+@keyframes hourglass-bottom {
+  0% {
+    transform: translate(-50%, 0);
+    opacity: 0.2;
+  }
+  50% {
+    transform: translate(-50%, -0.45rem);
+    opacity: 1;
+  }
+  100% {
+    transform: translate(-50%, 0);
+    opacity: 0.2;
+  }
 }
 
 #siret-error-link {
@@ -1620,6 +1774,96 @@ textarea {
   gap: 0.6rem;
 }
 
+body[data-viewport-mode='tablet'] .site-nav__inner,
+body[data-viewport-mode='mobile'] .site-nav__inner {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 1rem;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__actions {
+  width: 100%;
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__identity,
+body[data-viewport-mode='tablet'] .site-nav__cart-actions,
+body[data-viewport-mode='tablet'] .discount-field,
+body[data-viewport-mode='tablet'] .site-nav__tree,
+body[data-viewport-mode='tablet'] .viewport-toggle {
+  flex: 1 1 45%;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__tree,
+body[data-viewport-mode='mobile'] .site-nav__tree {
+  width: 100%;
+  margin-left: 0;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__cart-actions {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__cart-actions .btn-secondary,
+body[data-viewport-mode='mobile'] .site-nav__actions .btn-primary,
+body[data-viewport-mode='mobile'] .viewport-toggle,
+body[data-viewport-mode='mobile'] .discount-field {
+  width: 100%;
+}
+
+body[data-viewport-mode='mobile'] .viewport-toggle__button {
+  justify-content: center;
+}
+
+body[data-viewport-mode='mobile'] .discount-field {
+  display: flex;
+  justify-content: center;
+}
+
+body[data-viewport-mode='tablet'] .main-layout,
+body[data-viewport-mode='mobile'] .main-layout {
+  flex-direction: column;
+}
+
+body[data-viewport-mode='tablet'] #main-layout,
+body[data-viewport-mode='mobile'] #main-layout {
+  gap: 1rem;
+}
+
+body[data-viewport-mode='tablet'] #catalogue-panel,
+body[data-viewport-mode='tablet'] #quote-panel,
+body[data-viewport-mode='mobile'] #catalogue-panel,
+body[data-viewport-mode='mobile'] #quote-panel {
+  padding: 1.5rem;
+}
+
+body[data-viewport-mode='mobile'] #quote-panel {
+  order: 2;
+}
+
+body[data-viewport-mode='mobile'] #catalogue-panel {
+  order: 1;
+}
+
+body[data-viewport-mode='tablet'] .footer-inner,
+body[data-viewport-mode='mobile'] .footer-inner {
+  padding: 2.5rem 1.5rem;
+}
+
+body[data-viewport-mode='mobile'] .footer-meta {
+  flex-direction: column;
+  align-items: flex-start;
+}
+
 @media (max-width: 1024px) {
   .main-layout {
     flex-direction: column;
@@ -1639,19 +1883,6 @@ textarea {
   .site-nav__actions {
     width: 100%;
     justify-content: flex-start;
-  }
-
-  .site-nav__save-group {
-    width: 100%;
-    justify-content: space-between;
-  }
-
-  .save-name-field {
-    width: 100%;
-  }
-
-  .save-name-field input {
-    width: 100%;
   }
 
   .site-nav__identity,
@@ -1681,12 +1912,6 @@ textarea {
 
   .site-nav__actions .btn-primary {
     width: 100%;
-  }
-
-  .site-nav__save-group {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
   }
 
   .site-nav__cart-actions {

--- a/index.html
+++ b/index.html
@@ -85,76 +85,88 @@
               <span class="sr-only">Modifier</span>
             </button>
           </div>
-          <div class="site-nav__save-group">
-            <label for="save-name" class="save-name-field">
-              <span>Proposition</span>
-              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
-            </label>
-            <div class="site-nav__cart-actions">
-              <button
-                id="save-cart"
-                type="button"
-                class="btn-secondary btn-icon"
-                data-tooltip="Sauvegarder le panier"
-                aria-label="Sauvegarder le panier"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M9 3h6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M9 13h6v6H9z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Sauvegarder</span>
-              </button>
-              <button
-                id="restore-cart"
-                type="button"
-                class="btn-secondary btn-icon"
-                data-tooltip="Restaurer une sauvegarde"
-                aria-label="Restaurer une sauvegarde"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M4 4v6h6M20 20v-6h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Restaurer</span>
-              </button>
-              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-            </div>
+          <div class="site-nav__cart-actions">
+            <button
+              id="save-cart"
+              type="button"
+              class="btn-secondary btn-icon"
+              data-tooltip="Sauvegarder le panier"
+              aria-label="Sauvegarder le panier"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                <path
+                  d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M9 3h6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M9 13h6v6H9z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+              </svg>
+              <span class="sr-only">Sauvegarder</span>
+            </button>
+            <button
+              id="restore-cart"
+              type="button"
+              class="btn-secondary btn-icon"
+              data-tooltip="Restaurer une sauvegarde"
+              aria-label="Restaurer une sauvegarde"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                <path
+                  d="M4 4v6h6M20 20v-6h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+              </svg>
+              <span class="sr-only">Restaurer</span>
+            </button>
+            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+          </div>
+          <div class="viewport-toggle" data-mode="desktop">
+            <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
+              <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
+                <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
+                <rect
+                  data-role="viewport-stand"
+                  class="viewport-toggle__icon-stand"
+                  x="12"
+                  y="26"
+                  width="8"
+                  height="2"
+                  rx="1"
+                  ry="1"
+                />
+              </svg>
+              <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
+            </button>
           </div>
           <div class="discount-field" aria-live="polite">
             <span>Remise</span>
@@ -209,24 +221,7 @@
             <span class="sr-only">Passer commande</span>
           </button>
           <div class="site-nav__tree">
-            <label
-              for="catalogue-tree"
-              class="site-nav__tree-label icon-label"
-              data-tooltip="Sélectionner une catégorie"
-              aria-label="Sélectionner une catégorie"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 6h16M4 12h16M4 18h16"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sélectionner une catégorie</span>
-            </label>
+            <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
             <select id="catalogue-tree" class="site-nav__tree-select">
               <option value="">Sélectionner une catégorie ou un article</option>
             </select>
@@ -487,7 +482,38 @@
       </div>
     </template>
 
-      <div id="product-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" data-open="false">
+    <div
+      id="save-cart-modal"
+      class="modal-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="save-cart-title"
+      data-open="false"
+    >
+      <div class="modal-card save-cart-modal">
+        <form id="save-cart-form" class="modal-body save-cart-modal__body">
+          <h2 id="save-cart-title" class="save-cart-modal__title">Sauvegarder le panier</h2>
+          <p class="save-cart-modal__subtitle">Choisissez un nom pour retrouver facilement votre sélection.</p>
+          <label for="save-cart-name" class="save-cart-modal__label">Nom du panier</label>
+          <input
+            id="save-cart-name"
+            name="saveCartName"
+            type="text"
+            maxlength="80"
+            class="save-cart-modal__input"
+            placeholder="Ex. Projet magasin"
+            required
+          />
+          <p id="save-cart-error" class="form-error" role="alert" hidden></p>
+          <div class="modal-actions save-cart-modal__actions">
+            <button id="save-cart-cancel" type="button" class="btn-secondary">Annuler</button>
+            <button type="submit" class="btn-primary">Sauvegarder</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div id="product-modal" class="modal-backdrop" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" data-open="false">
         <div class="modal-card">
           <img id="product-modal-image" alt="" />
           <div class="modal-body">
@@ -618,6 +644,13 @@
         <button id="webhook-panel-close" type="button" class="webhook-panel__close" aria-label="Fermer">×</button>
       </div>
       <div id="webhook-panel-content" class="webhook-panel__content"></div>
+    </div>
+
+    <div id="global-loader" class="loader-backdrop" role="status" aria-live="assertive" hidden>
+      <div class="loader-card">
+        <div class="loader-hourglass" aria-hidden="true"></div>
+        <p id="global-loader-message">Préparation en cours…</p>
+      </div>
     </div>
 
     <footer class="site-footer">


### PR DESCRIPTION
## Résumé
- réduction du bloc de sélection de catégories et ajout du bouton de bascule des modes d’affichage
- implémentation du modal de sauvegarde du panier et mise à jour des actions associées
- ajout du loader "sablier" durant l’envoi de commande et refonte de l’activation du mode debug

## Tests
- Aucune suite automatisée disponible

------
https://chatgpt.com/codex/tasks/task_b_68e62ae4a5408329b8acd3e77456011e