### PR TITLE
Ajustements mobile et tablette pour la navigation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -227,8 +227,24 @@ textarea {
   flex: 1;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-start;
+  gap: 0.75rem;
+}
+
+.site-nav__command-group {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
   justify-content: flex-end;
   gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-left: auto;
+}
+
+.mobile-panel-toggle {
+  display: none;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .site-nav__tree {
@@ -1781,43 +1797,67 @@ body[data-viewport-mode='mobile'] .site-nav__inner {
   gap: 1rem;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__actions {
+body[data-viewport-mode='tablet'] .site-nav__actions,
+body[data-viewport-mode='mobile'] .site-nav__actions {
   width: 100%;
-  justify-content: flex-start;
+  align-items: center;
   gap: 0.75rem;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__identity,
-body[data-viewport-mode='tablet'] .site-nav__cart-actions,
-body[data-viewport-mode='tablet'] .discount-field,
-body[data-viewport-mode='tablet'] .site-nav__tree,
-body[data-viewport-mode='tablet'] .viewport-toggle {
-  flex: 1 1 45%;
+body[data-viewport-mode='tablet'] .site-nav__actions {
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__actions {
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  gap: 0.5rem;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__command-group {
+  gap: 0.75rem;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__command-group {
+  flex-wrap: nowrap;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  overflow-x: auto;
+  padding-bottom: 0.25rem;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__tree,
 body[data-viewport-mode='mobile'] .site-nav__tree {
-  width: 100%;
-  margin-left: 0;
+  display: none !important;
 }
 
-body[data-viewport-mode='mobile'] .site-nav__actions {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.75rem;
+body[data-viewport-mode='tablet'] .mobile-panel-toggle,
+body[data-viewport-mode='mobile'] .mobile-panel-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.85rem;
+  font-size: 0.85rem;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__cart-actions,
+body[data-viewport-mode='mobile'] .site-nav__cart-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 body[data-viewport-mode='mobile'] .site-nav__cart-actions {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.5rem;
+  flex-wrap: nowrap;
 }
 
 body[data-viewport-mode='mobile'] .site-nav__cart-actions .btn-secondary,
 body[data-viewport-mode='mobile'] .site-nav__actions .btn-primary,
 body[data-viewport-mode='mobile'] .viewport-toggle,
 body[data-viewport-mode='mobile'] .discount-field {
-  width: 100%;
+  width: auto;
 }
 
 body[data-viewport-mode='mobile'] .viewport-toggle__button {
@@ -1825,8 +1865,57 @@ body[data-viewport-mode='mobile'] .viewport-toggle__button {
 }
 
 body[data-viewport-mode='mobile'] .discount-field {
-  display: flex;
+  display: inline-flex;
+  align-items: center;
   justify-content: center;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__identity,
+body[data-viewport-mode='mobile'] .site-nav__identity {
+  padding: 0;
+  border: none;
+  background: transparent;
+  flex: 0 0 auto;
+  min-width: 0;
+  position: relative;
+  gap: 0.25rem;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__identity-controls,
+body[data-viewport-mode='mobile'] .site-nav__identity-controls {
+  width: auto;
+  gap: 0;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__identity-input,
+body[data-viewport-mode='mobile'] .site-nav__identity-input {
+  width: 16ch;
+  max-width: 100%;
+  padding: 0.45rem 0.65rem;
+  border-radius: 999px;
+  text-align: center;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__identity-label,
+body[data-viewport-mode='mobile'] .site-nav__identity-label,
+body[data-viewport-mode='tablet'] #siret-submit,
+body[data-viewport-mode='mobile'] #siret-submit {
+  display: none !important;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__identity-feedback,
+body[data-viewport-mode='mobile'] .site-nav__identity-feedback {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 body[data-viewport-mode='tablet'] .main-layout,
@@ -1844,6 +1933,21 @@ body[data-viewport-mode='tablet'] #quote-panel,
 body[data-viewport-mode='mobile'] #catalogue-panel,
 body[data-viewport-mode='mobile'] #quote-panel {
   padding: 1.5rem;
+}
+
+body[data-viewport-mode='mobile'][data-mobile-panel='catalogue'] .site-footer,
+body[data-viewport-mode='tablet'][data-mobile-panel='catalogue'] .site-footer {
+  display: none;
+}
+
+body[data-viewport-mode='mobile'][data-mobile-panel='footer'] main,
+body[data-viewport-mode='tablet'][data-mobile-panel='footer'] main {
+  display: none;
+}
+
+body[data-viewport-mode='mobile'][data-mobile-panel='footer'] .site-footer,
+body[data-viewport-mode='tablet'][data-mobile-panel='footer'] .site-footer {
+  display: block;
 }
 
 body[data-viewport-mode='mobile'] #quote-panel {
@@ -1878,19 +1982,7 @@ body[data-viewport-mode='mobile'] .footer-meta {
   .site-nav__inner {
     flex-direction: column;
     align-items: flex-start;
-  }
-
-  .site-nav__actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .site-nav__identity,
-  .site-nav__cart-actions,
-  .site-nav__tree {
-    width: 100%;
-    flex: 1 1 100%;
-    margin-left: 0;
+    gap: 1rem;
   }
 
   #main-layout {
@@ -1904,25 +1996,6 @@ body[data-viewport-mode='mobile'] .footer-meta {
 }
 
 @media (max-width: 640px) {
-  .site-nav__actions {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
-  }
-
-  .site-nav__actions .btn-primary {
-    width: 100%;
-  }
-
-  .site-nav__cart-actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .site-nav__cart-actions .btn-secondary {
-    width: 100%;
-  }
-
   .product-card {
     padding: 1.25rem;
   }

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <script src="https://unpkg.com/split.js/dist/split.min.js" defer></script>
     <script src="js/app.js" type="module" defer></script>
   </head>
-  <body class="site-body min-h-screen">
+  <body class="site-body min-h-screen" data-mobile-panel="catalogue">
     <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
       <div class="site-nav__inner">
         <div class="site-nav__branding">
@@ -59,43 +59,133 @@
             </div>
             <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
           </form>
-          <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
-            <div class="site-nav__client-text">
-              <p id="client-identity-name" class="site-nav__client-name"></p>
-              <p id="client-identity-meta" class="site-nav__client-meta"></p>
-              <p id="client-identity-register" class="site-nav__client-register">
-                <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
-                  >S'enregistrer comme nouveau client</a
-                >
-              </p>
+          <div class="site-nav__command-group">
+            <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
+              <div class="site-nav__client-text">
+                <p id="client-identity-name" class="site-nav__client-name"></p>
+                <p id="client-identity-meta" class="site-nav__client-meta"></p>
+                <p id="client-identity-register" class="site-nav__client-register">
+                  <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+                    >S'enregistrer comme nouveau client</a
+                  >
+                </p>
+              </div>
+              <button
+                id="client-identity-reset"
+                type="button"
+                class="btn-secondary btn-secondary--compact btn-icon"
+                data-tooltip="Modifier l'identification"
+                aria-label="Modifier l'identification"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12.56 5.56l3.75 3.75 1.96-1.6Z"
+                    fill="currentColor"
+                  />
+                </svg>
+                <span class="sr-only">Modifier</span>
+              </button>
+            </div>
+            <div class="site-nav__cart-actions">
+              <button
+                id="save-cart"
+                type="button"
+                class="btn-secondary btn-icon"
+                data-tooltip="Sauvegarder le panier"
+                aria-label="Sauvegarder le panier"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M9 3h6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M9 13h6v6H9z"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                </svg>
+                <span class="sr-only">Sauvegarder</span>
+              </button>
+              <button
+                id="restore-cart"
+                type="button"
+                class="btn-secondary btn-icon"
+                data-tooltip="Restaurer une sauvegarde"
+                aria-label="Restaurer une sauvegarde"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M4 4v6h6M20 20v-6h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                </svg>
+                <span class="sr-only">Restaurer</span>
+              </button>
+              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+            </div>
+            <button id="mobile-panel-toggle" type="button" class="btn-secondary mobile-panel-toggle" aria-pressed="false">
+              Voir le pied de page
+            </button>
+            <div class="viewport-toggle" data-mode="desktop">
+              <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
+                <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
+                  <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
+                  <rect
+                    data-role="viewport-stand"
+                    class="viewport-toggle__icon-stand"
+                    x="12"
+                    y="26"
+                    width="8"
+                    height="2"
+                    rx="1"
+                    ry="1"
+                  />
+                </svg>
+                <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
+              </button>
+            </div>
+            <div class="discount-field" aria-live="polite">
+              <span>Remise</span>
+              <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
             </div>
             <button
-              id="client-identity-reset"
+              id="generate-pdf"
+              class="btn-primary btn-icon"
+              data-tooltip="Imprimer le devis"
+              aria-label="Imprimer le devis"
               type="button"
-              class="btn-secondary btn-secondary--compact btn-icon"
-              data-tooltip="Modifier l'identification"
-              aria-label="Modifier l'identification"
             >
               <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
                 <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span class="sr-only">Modifier</span>
-            </button>
-          </div>
-          <div class="site-nav__cart-actions">
-            <button
-              id="save-cart"
-              type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Sauvegarder le panier"
-              aria-label="Sauvegarder le panier"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                  d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
                   fill="none"
                   stroke="currentColor"
                   stroke-linecap="round"
@@ -103,15 +193,7 @@
                   stroke-width="1.5"
                 />
                 <path
-                  d="M9 3h6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 13h6v6H9z"
+                  d="M7 13h10v8H7z"
                   fill="none"
                   stroke="currentColor"
                   stroke-linecap="round"
@@ -119,114 +201,36 @@
                   stroke-width="1.5"
                 />
               </svg>
-              <span class="sr-only">Sauvegarder</span>
+              <span class="sr-only">Imprimer</span>
             </button>
             <button
-              id="restore-cart"
+              id="submit-order"
+              class="btn-primary btn-icon"
+              data-tooltip="Passer commande"
+              aria-label="Passer commande"
               type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Restaurer une sauvegarde"
-              aria-label="Restaurer une sauvegarde"
             >
               <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
                 <path
-                  d="M4 4v6h6M20 20v-6h-6"
+                  d="M3 5h2l2 12h12l2-8H6"
                   fill="none"
                   stroke="currentColor"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   stroke-width="1.5"
                 />
-                <path
-                  d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
+                <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                <circle cx="18" cy="19" r="1.5" fill="currentColor" />
               </svg>
-              <span class="sr-only">Restaurer</span>
+              <span class="sr-only">Passer commande</span>
             </button>
-            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+            <div class="site-nav__tree">
+              <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
+              <select id="catalogue-tree" class="site-nav__tree-select">
+                <option value="">Sélectionner une catégorie ou un article</option>
+              </select>
+            </div>
           </div>
-          <div class="viewport-toggle" data-mode="desktop">
-            <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
-              <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
-                <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
-                <rect
-                  data-role="viewport-stand"
-                  class="viewport-toggle__icon-stand"
-                  x="12"
-                  y="26"
-                  width="8"
-                  height="2"
-                  rx="1"
-                  ry="1"
-                />
-              </svg>
-              <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
-            </button>
-          </div>
-          <div class="discount-field" aria-live="polite">
-            <span>Remise</span>
-            <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
-          </div>
-          <button
-            id="generate-pdf"
-            class="btn-primary btn-icon"
-            data-tooltip="Imprimer le devis"
-            aria-label="Imprimer le devis"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <path
-                d="M7 13h10v8H7z"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-            </svg>
-            <span class="sr-only">Imprimer</span>
-          </button>
-          <button
-            id="submit-order"
-            class="btn-primary btn-icon"
-            data-tooltip="Passer commande"
-            aria-label="Passer commande"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M3 5h2l2 12h12l2-8H6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <circle cx="9" cy="19" r="1.5" fill="currentColor" />
-              <circle cx="18" cy="19" r="1.5" fill="currentColor" />
-            </svg>
-            <span class="sr-only">Passer commande</span>
-          </button>
-          <div class="site-nav__tree">
-            <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
-              <option value="">Sélectionner une catégorie ou un article</option>
-            </select>
-          </div>
-        </div>
       </div>
     </nav>
     <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">

--- a/js/app.js
+++ b/js/app.js
@@ -106,6 +106,7 @@ const state = {
   lastOrderDetails: null,
   viewportMode: 'auto',
   detectedViewportMode: 'desktop',
+  mobilePanelView: 'catalogue',
 };
 
 const elements = {
@@ -167,6 +168,7 @@ const elements = {
   viewportToggleWrapper: document.querySelector('.viewport-toggle'),
   viewportIconScreen: document.querySelector('[data-role="viewport-screen"]'),
   viewportIconStand: document.querySelector('[data-role="viewport-stand"]'),
+  mobilePanelToggle: document.getElementById('mobile-panel-toggle'),
   siretForm: document.getElementById('siret-form'),
   siretInput: document.getElementById('siret-input'),
   siretSubmit: document.getElementById('siret-submit'),
@@ -218,6 +220,7 @@ document.addEventListener('DOMContentLoaded', () => {
   elements.brandLogo?.addEventListener('click', toggleWebhookMode);
   elements.brandLogo?.addEventListener('dblclick', handleBrandLogoDoubleClick);
   elements.viewportToggle?.addEventListener('click', handleViewportToggleClick);
+  elements.mobilePanelToggle?.addEventListener('click', toggleMobilePanelView);
   elements.webhookPanelClose?.addEventListener('click', closeWebhookPanel);
   elements.clientIdentityReset?.addEventListener('click', handleClientIdentityReset);
   elements.siretErrorClose?.addEventListener('click', closeSiretErrorModal);
@@ -327,9 +330,47 @@ function applyViewportMode() {
   if (document.body) {
     document.body.setAttribute('data-viewport-mode', mode);
   }
+  syncMobilePanelWithViewport(mode);
   updateViewportToggleLabel();
   updateViewportIcon(mode);
   setupResponsiveSplit();
+}
+
+function syncMobilePanelWithViewport(mode) {
+  if (!document.body) {
+    return;
+  }
+  if (mode === 'desktop') {
+    state.mobilePanelView = 'catalogue';
+  }
+  document.body.setAttribute('data-mobile-panel', state.mobilePanelView);
+  updateMobilePanelToggle();
+}
+
+function setMobilePanelView(view) {
+  const next = view === 'footer' ? 'footer' : 'catalogue';
+  state.mobilePanelView = next;
+  if (document.body) {
+    document.body.setAttribute('data-mobile-panel', next);
+  }
+  updateMobilePanelToggle();
+}
+
+function toggleMobilePanelView() {
+  const next = state.mobilePanelView === 'footer' ? 'catalogue' : 'footer';
+  setMobilePanelView(next);
+}
+
+function updateMobilePanelToggle() {
+  if (!elements.mobilePanelToggle) {
+    return;
+  }
+  const showingFooter = state.mobilePanelView === 'footer';
+  const label = showingFooter ? 'Voir la recherche' : 'Voir le pied de page';
+  const ariaLabel = showingFooter ? "Afficher la liste de recherche" : "Afficher le pied de page";
+  elements.mobilePanelToggle.textContent = label;
+  elements.mobilePanelToggle.setAttribute('aria-pressed', showingFooter ? 'true' : 'false');
+  elements.mobilePanelToggle.setAttribute('aria-label', ariaLabel);
 }
 
 function getNextViewportMode(current = state.viewportMode) {


### PR DESCRIPTION
## Summary
- restructure la barre de navigation pour regrouper les commandes et ajouter un bouton de bascule pied de page/recherche sur mobile
- adapte le formulaire SIRET et les styles responsive pour les modes mobile et tablette
- ajoute la logique JS permettant de basculer entre les vues catalogue et pied de page sur écrans réduits

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_b_68e640a62b90832989ee7eb8812f24df