### PR TITLE
Optimiser la navigation mobile du devis

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -374,6 +374,26 @@ textarea {
   white-space: nowrap;
 }
 
+.site-nav__command-bar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.site-nav__mobile-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.8rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
 .viewport-toggle {
   display: flex;
   align-items: center;
@@ -1865,6 +1885,91 @@ body[data-viewport-mode='mobile'] .footer-meta {
 }
 
 @media (max-width: 1024px) {
+  .site-nav__inner {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .site-nav__actions {
+    width: 100%;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 0.75rem;
+  }
+
+  .site-nav__command-bar {
+    width: 100%;
+    justify-content: flex-end;
+    gap: 0.6rem;
+  }
+
+  .site-nav__cart-actions {
+    justify-content: flex-end;
+  }
+
+  .site-nav__tree {
+    display: none !important;
+  }
+
+  .site-nav__identity {
+    flex: 0 1 auto;
+    min-width: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    box-shadow: none;
+    position: relative;
+  }
+
+  .site-nav__identity::before,
+  .site-nav__identity::after {
+    display: none;
+  }
+
+  .site-nav__identity-label,
+  #siret-submit {
+    display: none;
+  }
+
+  .site-nav__identity-controls {
+    gap: 0;
+  }
+
+  .site-nav__identity-input {
+    width: 14ch;
+    max-width: 100%;
+    text-align: center;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+  }
+
+  .site-nav__identity-feedback {
+    position: absolute;
+    top: calc(100% + 0.25rem);
+    left: 0;
+    width: 100%;
+    font-size: 0.7rem;
+    line-height: 1.2;
+  }
+
+  #client-identity {
+    width: 100%;
+  }
+
+  body[data-mobile-view='search'] .site-footer {
+    display: none;
+  }
+
+  body[data-mobile-view='footer'] #catalogue-panel {
+    display: none;
+  }
+
+  body[data-mobile-view='footer'] .site-footer {
+    display: block;
+  }
+
   .main-layout {
     flex-direction: column;
   }
@@ -1875,22 +1980,16 @@ body[data-viewport-mode='mobile'] .footer-meta {
 }
 
 @media (max-width: 768px) {
-  .site-nav__inner {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
   .site-nav__actions {
-    width: 100%;
-    justify-content: flex-start;
+    align-items: stretch;
   }
 
-  .site-nav__identity,
-  .site-nav__cart-actions,
-  .site-nav__tree {
-    width: 100%;
-    flex: 1 1 100%;
-    margin-left: 0;
+  .site-nav__command-bar {
+    gap: 0.5rem;
+  }
+
+  .site-nav__cart-actions {
+    flex: 0 1 auto;
   }
 
   #main-layout {
@@ -1907,20 +2006,28 @@ body[data-viewport-mode='mobile'] .footer-meta {
   .site-nav__actions {
     flex-direction: column;
     align-items: stretch;
-    gap: 0.5rem;
+    gap: 0.75rem;
   }
 
   .site-nav__actions .btn-primary {
-    width: 100%;
+    width: auto;
+  }
+
+  .site-nav__command-bar {
+    justify-content: flex-end;
+    gap: 0.45rem;
   }
 
   .site-nav__cart-actions {
-    flex-direction: column;
-    align-items: stretch;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.45rem;
+    width: 100%;
   }
 
   .site-nav__cart-actions .btn-secondary {
-    width: 100%;
+    width: auto;
   }
 
   .product-card {

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
                 type="text"
                 inputmode="numeric"
                 maxlength="14"
-                placeholder="Numéro SIRET (14 chiffres)"
+                placeholder="SIRET (14 chiffres)"
                 class="site-nav__identity-input"
               />
               <button
@@ -85,17 +85,107 @@
               <span class="sr-only">Modifier</span>
             </button>
           </div>
-          <div class="site-nav__cart-actions">
+          <div class="site-nav__command-bar">
+            <button id="mobile-content-toggle" type="button" class="btn-secondary site-nav__mobile-toggle" hidden>
+              Voir le pied de page
+            </button>
+            <div class="site-nav__cart-actions">
+              <button
+                id="save-cart"
+                type="button"
+                class="btn-secondary btn-icon"
+                data-tooltip="Sauvegarder le panier"
+                aria-label="Sauvegarder le panier"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M9 3h6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M9 13h6v6H9z"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                </svg>
+                <span class="sr-only">Sauvegarder</span>
+              </button>
+              <button
+                id="restore-cart"
+                type="button"
+                class="btn-secondary btn-icon"
+                data-tooltip="Restaurer une sauvegarde"
+                aria-label="Restaurer une sauvegarde"
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M4 4v6h6M20 20v-6h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                </svg>
+                <span class="sr-only">Restaurer</span>
+              </button>
+              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+            </div>
+            <div class="viewport-toggle" data-mode="desktop">
+              <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
+                <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
+                  <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
+                  <rect
+                    data-role="viewport-stand"
+                    class="viewport-toggle__icon-stand"
+                    x="12"
+                    y="26"
+                    width="8"
+                    height="2"
+                    rx="1"
+                    ry="1"
+                  />
+                </svg>
+                <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
+              </button>
+            </div>
+            <div class="discount-field" aria-live="polite">
+              <span>Remise</span>
+              <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
+            </div>
             <button
-              id="save-cart"
+              id="generate-pdf"
+              class="btn-primary btn-icon"
+              data-tooltip="Imprimer le devis"
+              aria-label="Imprimer le devis"
               type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Sauvegarder le panier"
-              aria-label="Sauvegarder le panier"
             >
               <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
                 <path
-                  d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                  d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
                   fill="none"
                   stroke="currentColor"
                   stroke-linecap="round"
@@ -103,15 +193,7 @@
                   stroke-width="1.5"
                 />
                 <path
-                  d="M9 3h6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 13h6v6H9z"
+                  d="M7 13h10v8H7z"
                   fill="none"
                   stroke="currentColor"
                   stroke-linecap="round"
@@ -119,107 +201,30 @@
                   stroke-width="1.5"
                 />
               </svg>
-              <span class="sr-only">Sauvegarder</span>
+              <span class="sr-only">Imprimer</span>
             </button>
             <button
-              id="restore-cart"
+              id="submit-order"
+              class="btn-primary btn-icon"
+              data-tooltip="Passer commande"
+              aria-label="Passer commande"
               type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Restaurer une sauvegarde"
-              aria-label="Restaurer une sauvegarde"
             >
               <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
                 <path
-                  d="M4 4v6h6M20 20v-6h-6"
+                  d="M3 5h2l2 12h12l2-8H6"
                   fill="none"
                   stroke="currentColor"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   stroke-width="1.5"
                 />
-                <path
-                  d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
+                <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                <circle cx="18" cy="19" r="1.5" fill="currentColor" />
               </svg>
-              <span class="sr-only">Restaurer</span>
-            </button>
-            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-          </div>
-          <div class="viewport-toggle" data-mode="desktop">
-            <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
-              <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
-                <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
-                <rect
-                  data-role="viewport-stand"
-                  class="viewport-toggle__icon-stand"
-                  x="12"
-                  y="26"
-                  width="8"
-                  height="2"
-                  rx="1"
-                  ry="1"
-                />
-              </svg>
-              <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
+              <span class="sr-only">Passer commande</span>
             </button>
           </div>
-          <div class="discount-field" aria-live="polite">
-            <span>Remise</span>
-            <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
-          </div>
-          <button
-            id="generate-pdf"
-            class="btn-primary btn-icon"
-            data-tooltip="Imprimer le devis"
-            aria-label="Imprimer le devis"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <path
-                d="M7 13h10v8H7z"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-            </svg>
-            <span class="sr-only">Imprimer</span>
-          </button>
-          <button
-            id="submit-order"
-            class="btn-primary btn-icon"
-            data-tooltip="Passer commande"
-            aria-label="Passer commande"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M3 5h2l2 12h12l2-8H6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <circle cx="9" cy="19" r="1.5" fill="currentColor" />
-              <circle cx="18" cy="19" r="1.5" fill="currentColor" />
-            </svg>
-            <span class="sr-only">Passer commande</span>
-          </button>
           <div class="site-nav__tree">
             <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
             <select id="catalogue-tree" class="site-nav__tree-select">

--- a/js/app.js
+++ b/js/app.js
@@ -76,6 +76,11 @@ const VIEWPORT_LABELS = {
   mobile: 'Téléphone',
 };
 
+const MOBILE_VIEW_TOGGLE_LABELS = {
+  search: 'Voir le pied de page',
+  footer: 'Voir la liste de recherche',
+};
+
 const state = {
   catalogue: [],
   filtered: [],
@@ -106,6 +111,7 @@ const state = {
   lastOrderDetails: null,
   viewportMode: 'auto',
   detectedViewportMode: 'desktop',
+  mobileView: 'search',
 };
 
 const elements = {
@@ -167,6 +173,7 @@ const elements = {
   viewportToggleWrapper: document.querySelector('.viewport-toggle'),
   viewportIconScreen: document.querySelector('[data-role="viewport-screen"]'),
   viewportIconStand: document.querySelector('[data-role="viewport-stand"]'),
+  mobileContentToggle: document.getElementById('mobile-content-toggle'),
   siretForm: document.getElementById('siret-form'),
   siretInput: document.getElementById('siret-input'),
   siretSubmit: document.getElementById('siret-submit'),
@@ -194,6 +201,7 @@ const elements = {
   orderCopy: document.getElementById('order-copy'),
   globalLoader: document.getElementById('global-loader'),
   globalLoaderMessage: document.getElementById('global-loader-message'),
+  siteFooter: document.querySelector('.site-footer'),
 };
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -218,6 +226,7 @@ document.addEventListener('DOMContentLoaded', () => {
   elements.brandLogo?.addEventListener('click', toggleWebhookMode);
   elements.brandLogo?.addEventListener('dblclick', handleBrandLogoDoubleClick);
   elements.viewportToggle?.addEventListener('click', handleViewportToggleClick);
+  elements.mobileContentToggle?.addEventListener('click', handleMobileContentToggle);
   elements.webhookPanelClose?.addEventListener('click', closeWebhookPanel);
   elements.clientIdentityReset?.addEventListener('click', handleClientIdentityReset);
   elements.siretErrorClose?.addEventListener('click', closeSiretErrorModal);
@@ -329,6 +338,7 @@ function applyViewportMode() {
   }
   updateViewportToggleLabel();
   updateViewportIcon(mode);
+  applyMobileViewState(mode);
   setupResponsiveSplit();
 }
 
@@ -402,6 +412,55 @@ function updateViewportIcon(mode) {
     elements.viewportIconStand.setAttribute('y', '26');
     elements.viewportIconStand.setAttribute('width', '8');
     elements.viewportIconStand.setAttribute('height', '2');
+  }
+}
+
+function applyMobileViewState(mode = getEffectiveViewportMode()) {
+  if (!document.body) {
+    return;
+  }
+  const effective = mode;
+  if (effective === 'mobile' || effective === 'tablet') {
+    const targetView = state.mobileView === 'footer' ? 'footer' : 'search';
+    document.body.setAttribute('data-mobile-view', targetView);
+  } else {
+    document.body.removeAttribute('data-mobile-view');
+  }
+  updateMobileToggleVisibility(effective);
+}
+
+function updateMobileToggleVisibility(mode = getEffectiveViewportMode()) {
+  if (!elements.mobileContentToggle) {
+    return;
+  }
+  const shouldShow = mode === 'mobile' || mode === 'tablet';
+  elements.mobileContentToggle.hidden = !shouldShow;
+  if (!shouldShow) {
+    elements.mobileContentToggle.removeAttribute('aria-pressed');
+    return;
+  }
+  updateMobileToggleLabel();
+  elements.mobileContentToggle.setAttribute('aria-pressed', state.mobileView === 'footer' ? 'true' : 'false');
+}
+
+function updateMobileToggleLabel() {
+  if (!elements.mobileContentToggle) {
+    return;
+  }
+  const label = MOBILE_VIEW_TOGGLE_LABELS[state.mobileView] || MOBILE_VIEW_TOGGLE_LABELS.search;
+  elements.mobileContentToggle.textContent = label;
+}
+
+function handleMobileContentToggle(event) {
+  if (event && typeof event.preventDefault === 'function') {
+    event.preventDefault();
+  }
+  state.mobileView = state.mobileView === 'search' ? 'footer' : 'search';
+  applyMobileViewState(getEffectiveViewportMode());
+  if (state.mobileView === 'footer' && elements.siteFooter) {
+    elements.siteFooter.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } else if (state.mobileView === 'search' && elements.cataloguePanel) {
+    elements.cataloguePanel.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }
 }
 


### PR DESCRIPTION
## Summary
- simplifier la zone d'identification SIRET et regrouper les actions d'en-tête dans une barre de commandes commune
- améliorer les styles responsives pour masquer la liste des catégories et aligner les commandes sur mobile et tablette, tout en ajoutant un bouton de bascule vers le pied de page
- gérer côté JavaScript l'affichage du nouveau bouton mobile et le masquage alternatif du catalogue et du pied de page selon le mode sélectionné

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e640a62b90832989ee7eb8812f24df