### PR TITLE
Optimiser la navigation mobile et tablette

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -374,6 +374,11 @@ textarea {
   white-space: nowrap;
 }
 
+.site-nav__footer-toggle {
+  display: none;
+  white-space: nowrap;
+}
+
 .viewport-toggle {
   display: flex;
   align-items: center;
@@ -1801,32 +1806,123 @@ body[data-viewport-mode='mobile'] .site-nav__tree {
   margin-left: 0;
 }
 
-body[data-viewport-mode='mobile'] .site-nav__actions {
+body[data-viewport-mode='mobile'] .site-nav__inner,
+body[data-viewport-mode='tablet'] .site-nav__inner {
   flex-direction: column;
   align-items: stretch;
   gap: 0.75rem;
 }
 
-body[data-viewport-mode='mobile'] .site-nav__cart-actions {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 0.5rem;
+body[data-viewport-mode='mobile'] .site-nav__branding,
+body[data-viewport-mode='tablet'] .site-nav__branding {
+  align-self: flex-start;
 }
 
-body[data-viewport-mode='mobile'] .site-nav__cart-actions .btn-secondary,
-body[data-viewport-mode='mobile'] .site-nav__actions .btn-primary,
-body[data-viewport-mode='mobile'] .viewport-toggle,
-body[data-viewport-mode='mobile'] .discount-field {
+body[data-viewport-mode='mobile'] .site-nav__actions,
+body[data-viewport-mode='tablet'] .site-nav__actions {
   width: 100%;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-auto-rows: auto;
+  column-gap: 0.75rem;
+  row-gap: 0.5rem;
+  align-items: center;
 }
 
-body[data-viewport-mode='mobile'] .viewport-toggle__button {
-  justify-content: center;
+body[data-viewport-mode='mobile'] #siret-form,
+body[data-viewport-mode='tablet'] #siret-form {
+  grid-column: 1;
+  min-width: auto;
+  flex: 0 0 auto;
+  padding: 0;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+  gap: 0.35rem;
+  align-items: flex-start;
 }
 
-body[data-viewport-mode='mobile'] .discount-field {
-  display: flex;
-  justify-content: center;
+body[data-viewport-mode='mobile'] .site-nav__identity[data-status],
+body[data-viewport-mode='tablet'] .site-nav__identity[data-status] {
+  border: none;
+  box-shadow: none;
+}
+
+body[data-viewport-mode='mobile'] #siret-form .site-nav__identity-controls,
+body[data-viewport-mode='tablet'] #siret-form .site-nav__identity-controls {
+  gap: 0;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__identity-label,
+body[data-viewport-mode='tablet'] .site-nav__identity-label {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+body[data-viewport-mode='mobile'] #siret-submit,
+body[data-viewport-mode='tablet'] #siret-submit {
+  display: none;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__identity-input,
+body[data-viewport-mode='tablet'] .site-nav__identity-input {
+  width: 14ch;
+  min-width: 14ch;
+  max-width: 14ch;
+  padding: 0.45rem 0.6rem;
+  text-align: center;
+  font-size: 0.85rem;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__identity-feedback,
+body[data-viewport-mode='tablet'] .site-nav__identity-feedback {
+  max-width: 14ch;
+  font-size: 0.68rem;
+  line-height: 1.2;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__actions > :not(#siret-form),
+body[data-viewport-mode='tablet'] .site-nav__actions > :not(#siret-form) {
+  grid-column: 2;
+  justify-self: end;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__client,
+body[data-viewport-mode='tablet'] .site-nav__client {
+  max-width: min(100%, 20rem);
+}
+
+body[data-viewport-mode='mobile'] .site-nav__cart-actions,
+body[data-viewport-mode='tablet'] .site-nav__cart-actions {
+  justify-content: flex-end;
+}
+
+body[data-viewport-mode='mobile'] .viewport-toggle__button,
+body[data-viewport-mode='tablet'] .viewport-toggle__button {
+  justify-content: flex-end;
+}
+
+body[data-viewport-mode='mobile'] .discount-field,
+body[data-viewport-mode='tablet'] .discount-field {
+  justify-content: flex-end;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__footer-toggle,
+body[data-viewport-mode='tablet'] .site-nav__footer-toggle {
+  display: inline-flex;
+  justify-self: end;
+}
+
+body[data-viewport-mode='mobile'] .site-nav__tree,
+body[data-viewport-mode='tablet'] .site-nav__tree {
+  display: none;
 }
 
 body[data-viewport-mode='tablet'] .main-layout,
@@ -1882,10 +1978,8 @@ body[data-viewport-mode='mobile'] .footer-meta {
 
   .site-nav__actions {
     width: 100%;
-    justify-content: flex-start;
   }
 
-  .site-nav__identity,
   .site-nav__cart-actions,
   .site-nav__tree {
     width: 100%;
@@ -1905,22 +1999,12 @@ body[data-viewport-mode='mobile'] .footer-meta {
 
 @media (max-width: 640px) {
   .site-nav__actions {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 0.5rem;
-  }
-
-  .site-nav__actions .btn-primary {
-    width: 100%;
+    row-gap: 0.35rem;
   }
 
   .site-nav__cart-actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .site-nav__cart-actions .btn-secondary {
-    width: 100%;
+    flex-wrap: wrap;
+    justify-content: flex-end;
   }
 
   .product-card {

--- a/index.html
+++ b/index.html
@@ -35,6 +35,7 @@
                 inputmode="numeric"
                 maxlength="14"
                 placeholder="Numéro SIRET (14 chiffres)"
+                aria-label="Numéro SIRET"
                 class="site-nav__identity-input"
               />
               <button
@@ -172,6 +173,14 @@
             <span>Remise</span>
             <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
           </div>
+          <button
+            id="footer-toggle"
+            type="button"
+            class="btn-secondary site-nav__footer-toggle"
+            data-state="catalogue"
+          >
+            Voir le pied de page
+          </button>
           <button
             id="generate-pdf"
             class="btn-primary btn-icon"

--- a/js/app.js
+++ b/js/app.js
@@ -167,6 +167,8 @@ const elements = {
   viewportToggleWrapper: document.querySelector('.viewport-toggle'),
   viewportIconScreen: document.querySelector('[data-role="viewport-screen"]'),
   viewportIconStand: document.querySelector('[data-role="viewport-stand"]'),
+  footerToggle: document.getElementById('footer-toggle'),
+  siteFooter: document.querySelector('.site-footer'),
   siretForm: document.getElementById('siret-form'),
   siretInput: document.getElementById('siret-input'),
   siretSubmit: document.getElementById('siret-submit'),
@@ -218,6 +220,7 @@ document.addEventListener('DOMContentLoaded', () => {
   elements.brandLogo?.addEventListener('click', toggleWebhookMode);
   elements.brandLogo?.addEventListener('dblclick', handleBrandLogoDoubleClick);
   elements.viewportToggle?.addEventListener('click', handleViewportToggleClick);
+  elements.footerToggle?.addEventListener('click', handleFooterToggleClick);
   elements.webhookPanelClose?.addEventListener('click', closeWebhookPanel);
   elements.clientIdentityReset?.addEventListener('click', handleClientIdentityReset);
   elements.siretErrorClose?.addEventListener('click', closeSiretErrorModal);
@@ -242,6 +245,7 @@ document.addEventListener('DOMContentLoaded', () => {
   setIdentificationState('idle');
   renderClientIdentity();
   applyFieldTooltips();
+  updateFooterToggleLabel();
 });
 
 function setupResponsiveSplit() {
@@ -329,6 +333,7 @@ function applyViewportMode() {
   }
   updateViewportToggleLabel();
   updateViewportIcon(mode);
+  resetFooterToggleState(mode);
   setupResponsiveSplit();
 }
 
@@ -344,6 +349,46 @@ function formatViewportLabel(mode) {
   const baseMode = mode === 'auto' ? state.detectedViewportMode : mode;
   const baseLabel = VIEWPORT_LABELS[baseMode] || VIEWPORT_LABELS.desktop;
   return mode === 'auto' ? `Mode auto : ${baseLabel}` : `Mode : ${baseLabel}`;
+}
+
+function handleFooterToggleClick() {
+  if (!elements.footerToggle) {
+    return;
+  }
+  const currentState = elements.footerToggle.dataset.state === 'footer' ? 'footer' : 'catalogue';
+  const nextState = currentState === 'footer' ? 'catalogue' : 'footer';
+  elements.footerToggle.dataset.state = nextState;
+  if (nextState === 'footer') {
+    elements.siteFooter?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  } else {
+    elements.cataloguePanel?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+  updateFooterToggleLabel();
+}
+
+function updateFooterToggleLabel() {
+  if (!elements.footerToggle) {
+    return;
+  }
+  const state = elements.footerToggle.dataset.state === 'footer' ? 'footer' : 'catalogue';
+  const label = state === 'footer' ? 'Voir la recherche' : 'Voir le pied de page';
+  elements.footerToggle.textContent = label;
+  elements.footerToggle.setAttribute('aria-label', label);
+}
+
+function resetFooterToggleState(mode = getEffectiveViewportMode()) {
+  if (!elements.footerToggle) {
+    return;
+  }
+  if (mode !== 'mobile' && mode !== 'tablet') {
+    elements.footerToggle.dataset.state = 'catalogue';
+    updateFooterToggleLabel();
+    return;
+  }
+  if (!elements.footerToggle.dataset.state) {
+    elements.footerToggle.dataset.state = 'catalogue';
+  }
+  updateFooterToggleLabel();
 }
 
 function updateViewportToggleLabel() {


### PR DESCRIPTION
## Summary
- Simplified the SIRET identification block on mobile and tablet while aligning navigation actions with the branding
- Hid the category selector on small viewports and introduced a toggle to jump between the search list and the footer
- Updated styles and scripts to support the new responsive header behaviour and improved accessibility labels

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e640a62b90832989ee7eb8812f24df