### PR TITLE
feat: ajouter la configuration des filtres produits

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -231,6 +231,133 @@ textarea {
   gap: 0.75rem;
 }
 
+.site-nav__filter-config {
+  position: relative;
+}
+
+.site-nav__filter-config-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.site-nav__filter-config-trigger .icon {
+  width: 1rem;
+  height: 1rem;
+}
+
+.site-nav__filter-config-trigger[data-has-active='true'] {
+  color: var(--color-primary);
+  border-color: rgba(228, 30, 40, 0.35);
+  background: rgba(228, 30, 40, 0.12);
+  box-shadow: inset 0 1px 0 rgba(228, 30, 40, 0.15);
+}
+
+.site-nav__filter-config-count {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.filter-config-menu {
+  position: absolute;
+  inset-inline-end: 0;
+  top: calc(100% + 0.5rem);
+  width: min(22rem, 90vw);
+  max-height: 24rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  background: #fff;
+  box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
+  z-index: 60;
+}
+
+.filter-config-menu[data-open='true'] {
+  display: flex;
+}
+
+.filter-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.filter-config-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.filter-config-close {
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(25, 63, 96, 0.08);
+  color: var(--color-secondary);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.filter-config-close:hover,
+.filter-config-close:focus-visible {
+  background: rgba(25, 63, 96, 0.16);
+  color: var(--color-primary);
+  outline: none;
+}
+
+.filter-config-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding-inline-end: 0.25rem;
+}
+
+.filter-config-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(25, 63, 96, 0.06);
+  font-size: 0.85rem;
+  color: var(--color-secondary);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.filter-config-option input {
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-primary);
+  flex-shrink: 0;
+}
+
+.filter-config-option span {
+  flex: 1;
+}
+
+.filter-config-option:hover,
+.filter-config-option:focus-within {
+  background: rgba(25, 63, 96, 0.12);
+}
+
+.filter-config-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-muted-strong);
+  text-align: center;
+}
+
 .site-nav__tree {
   display: flex;
   flex-direction: column;
@@ -977,6 +1104,11 @@ textarea {
   z-index: 30;
 }
 
+#category-filter-button {
+  position: relative;
+  z-index: 40;
+}
+
 .category-filter-menu[data-open='true'] {
   display: flex;
 }
@@ -1036,6 +1168,10 @@ textarea {
   background: rgba(228, 30, 40, 0.15);
   color: var(--color-primary);
   font-weight: 600;
+}
+
+#extra-filters-container[data-visible='false'] {
+  display: none !important;
 }
 
 .quote-comment {

--- a/index.html
+++ b/index.html
@@ -158,6 +158,42 @@
           >
             <span id="mobile-view-toggle-label" class="site-nav__mobile-toggle-label">Voir le pied de page</span>
           </button>
+          <div class="site-nav__filter-config">
+            <button
+              id="filter-config-button"
+              type="button"
+              class="btn-secondary btn-secondary--compact site-nav__filter-config-trigger"
+              aria-haspopup="true"
+              aria-expanded="false"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                <path
+                  d="M10.325 4.317a1 1 0 0 1 1.35-.447l.098.052 1.825 1.054a1 1 0 0 0 .476.132h2.106a2 2 0 0 1 2 2v2.106a1 1 0 0 0 .132.476l1.054 1.825a1 1 0 0 1-.349 1.35l-.098.057-1.825 1.054a1 1 0 0 0-.476.132h-2.106a2 2 0 0 0-2 2v2.106a1 1 0 0 1-1.482.874l-.098-.057-1.825-1.054a1 1 0 0 0-.476-.132H7.718a2 2 0 0 1-2-2v-2.106a1 1 0 0 0-.132-.476L4.532 11.89a1 1 0 0 1 .349-1.35l.098-.057 1.825-1.054a1 1 0 0 0 .476-.132h2.106a2 2 0 0 0 2-2V5.146a1 1 0 0 1 .939-.829Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+              </svg>
+              <span class="site-nav__filter-config-label">Filtres supplémentaires</span>
+              <span id="filter-config-count" class="site-nav__filter-config-count" aria-hidden="true"></span>
+            </button>
+            <div
+              id="filter-config-menu"
+              class="filter-config-menu"
+              role="menu"
+              aria-labelledby="filter-config-button"
+              data-open="false"
+            >
+              <div class="filter-config-header">
+                <p class="filter-config-title">Filtres disponibles</p>
+                <button id="filter-config-close" type="button" class="filter-config-close">Fermer</button>
+              </div>
+              <div id="filter-config-list" class="filter-config-list" role="group" aria-label="Filtres supplémentaires"></div>
+              <p id="filter-config-empty" class="filter-config-empty">Aucun filtre supplémentaire disponible.</p>
+            </div>
+          </div>
           <div class="viewport-toggle" data-mode="desktop">
             <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
               <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
@@ -260,7 +296,7 @@
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
                 </svg>
               </div>
-              <div class="flex flex-col gap-3 sm:flex-row sm:items-center xl:w-auto">
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:flex-wrap xl:w-auto" id="product-filter-controls">
                 <div class="relative sm:w-56 xl:w-64">
                   <button
                     id="category-filter-button"
@@ -297,6 +333,11 @@
                     <option value="">Toutes les unités</option>
                   </select>
                 </label>
+                <div
+                  id="extra-filters-container"
+                  class="flex w-full flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center xl:w-auto"
+                  data-visible="false"
+                ></div>
               </div>
             </div>
           </header>


### PR DESCRIPTION
## Résumé
- ajoute un bouton de configuration des filtres dans la barre supérieure avec un menu listant les colonnes du CSV à partir de la 15ᵉ
- permet d'activer des filtres supplémentaires qui apparaissent dans la zone de recherche produit et participent au filtrage
- corrige la superposition du bouton de filtre par catégorie pour qu'il reste accessible

## Tests
- non applicable (application statique)


------
https://chatgpt.com/codex/tasks/task_b_68e65ca326108329ab932c4d79b5768e