### PR TITLE
Ajout d’une configuration avancée des filtres

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -374,6 +374,22 @@ textarea {
   white-space: nowrap;
 }
 
+.site-nav__config {
+  position: relative;
+}
+
+.site-nav__config-toggle {
+  min-width: 11rem;
+  justify-content: center;
+  font-weight: 600;
+}
+
+.site-nav__config-toggle[aria-disabled='true'],
+.site-nav__config-toggle:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 .site-nav__mobile-toggle {
   display: none;
   white-space: nowrap;
@@ -974,11 +990,16 @@ textarea {
   background: #fff;
   box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
   padding: 1rem;
-  z-index: 30;
+  z-index: 60;
 }
 
 .category-filter-menu[data-open='true'] {
   display: flex;
+}
+
+#category-filter-button {
+  position: relative;
+  z-index: 70;
 }
 
 #category-filter-button[aria-expanded='true'] [data-role='chevron'] {
@@ -1036,6 +1057,129 @@ textarea {
   background: rgba(228, 30, 40, 0.15);
   color: var(--color-primary);
   font-weight: 600;
+}
+
+.filter-config-menu {
+  position: absolute;
+  inset-inline-end: 0;
+  margin-top: 0.75rem;
+  width: min(22rem, 90vw);
+  max-height: 26rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  background: #fff;
+  box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
+  padding: 1rem;
+  z-index: 70;
+}
+
+.filter-config-menu[data-open='true'] {
+  display: flex;
+}
+
+.filter-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.filter-config-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.filter-config-close {
+  border: none;
+  background: transparent;
+  color: var(--color-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.filter-config-close:hover,
+.filter-config-close:focus-visible {
+  background: rgba(228, 30, 40, 0.1);
+  outline: none;
+}
+
+.filter-config-description {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-muted-strong);
+}
+
+.filter-config-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding-inline-end: 0.25rem;
+}
+
+.filter-config-option {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-secondary);
+  background: rgba(25, 63, 96, 0.06);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.filter-config-option:hover,
+.filter-config-option:focus-within {
+  background: rgba(25, 63, 96, 0.12);
+}
+
+.filter-config-option input {
+  accent-color: var(--color-primary);
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+}
+
+.filter-config-option span {
+  flex: 1;
+}
+
+.filter-config-option.is-active {
+  background: rgba(228, 30, 40, 0.15);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
+.extra-filter-controls {
+  width: 100%;
+}
+
+.extra-filter-control {
+  flex: 1 1 16rem;
+  min-width: 14rem;
+}
+
+.extra-filter-control__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-muted);
+}
+
+.extra-filter-control__select {
+  width: 100%;
 }
 
 .quote-comment {

--- a/index.html
+++ b/index.html
@@ -150,6 +150,33 @@
             </button>
             <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
           </div>
+          <div class="site-nav__config">
+            <button
+              id="filter-config-button"
+              type="button"
+              class="btn-secondary site-nav__config-toggle"
+              aria-haspopup="true"
+              aria-expanded="false"
+            >
+              Configurer les filtres
+            </button>
+            <div
+              id="filter-config-menu"
+              class="filter-config-menu"
+              role="menu"
+              aria-labelledby="filter-config-button"
+              data-open="false"
+            >
+              <div class="filter-config-header">
+                <p class="filter-config-title">Filtres supplémentaires</p>
+                <button id="filter-config-close" type="button" class="filter-config-close">Fermer</button>
+              </div>
+              <p class="filter-config-description">
+                Sélectionnez les colonnes à afficher dans la recherche produit pour affiner vos résultats.
+              </p>
+              <div id="filter-config-options" class="filter-config-options" role="group"></div>
+            </div>
+          </div>
           <button
             id="mobile-view-toggle"
             type="button"
@@ -248,11 +275,11 @@
               </p>
             </div>
             <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-              <div class="relative w-full lg:max-w-md">
-                <label for="search" class="sr-only">Rechercher un produit</label>
-                <input
-                  id="search"
-                  type="search"
+            <div class="relative w-full lg:max-w-md">
+              <label for="search" class="sr-only">Rechercher un produit</label>
+              <input
+                id="search"
+                type="search"
                   placeholder="Rechercher par nom ou référence..."
                   class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-11 pr-4 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 brand-input"
                 />
@@ -299,6 +326,7 @@
                 </label>
               </div>
             </div>
+            <div id="extra-filter-controls" class="extra-filter-controls mt-2 flex flex-wrap gap-3" hidden></div>
           </header>
           <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
           <div id="product-grid" class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>


### PR DESCRIPTION
## Summary
- ajoute un bouton de configuration dans la barre supérieure pour gérer les filtres produits supplémentaires
- met en avant le bouton de filtre de catégories afin qu’il reste visible au-dessus de la grille produits
- introduit la gestion dynamique des filtres issus des colonnes du catalogue (à partir de la 15ᵉ) et leur affichage dans la recherche

## Testing
- not run (non disponible)


------
https://chatgpt.com/codex/tasks/task_b_68e65ca326108329ab932c4d79b5768e