### PR TITLE
Ajoute la configuration des filtres avancés

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -374,6 +374,96 @@ textarea {
   white-space: nowrap;
 }
 
+.site-nav__config {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.site-nav__config-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.site-nav__config-toggle .icon {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.filter-config-menu {
+  position: absolute;
+  inset-inline-end: 0;
+  margin-top: 0.75rem;
+  width: min(22rem, 90vw);
+  max-height: 24rem;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  background: #fff;
+  box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
+  padding: 1rem;
+  z-index: 80;
+}
+
+.filter-config-menu[data-open='true'] {
+  display: flex;
+}
+
+.filter-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.filter-config-description {
+  font-size: 0.75rem;
+  color: var(--color-muted-strong);
+}
+
+.filter-config-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 16rem;
+  overflow-y: auto;
+  padding-inline-end: 0.25rem;
+}
+
+.filter-config-options label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--color-secondary);
+  background: rgba(25, 63, 96, 0.06);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.filter-config-options label:hover,
+.filter-config-options label:focus-within {
+  background: rgba(25, 63, 96, 0.12);
+}
+
+.filter-config-options input {
+  accent-color: var(--color-primary);
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+}
+
+.filter-config-options label.is-active {
+  background: rgba(228, 30, 40, 0.15);
+  color: var(--color-primary);
+  font-weight: 600;
+}
+
 .site-nav__mobile-toggle {
   display: none;
   white-space: nowrap;
@@ -974,7 +1064,7 @@ textarea {
   background: #fff;
   box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
   padding: 1rem;
-  z-index: 30;
+  z-index: 70;
 }
 
 .category-filter-menu[data-open='true'] {
@@ -1036,6 +1126,24 @@ textarea {
   background: rgba(228, 30, 40, 0.15);
   color: var(--color-primary);
   font-weight: 600;
+}
+
+.catalogue-header {
+  position: relative;
+  z-index: 10;
+}
+
+#category-filter-button {
+  position: relative;
+  z-index: 40;
+}
+
+.dynamic-filter-control {
+  flex: 1 1 12rem;
+}
+
+.dynamic-filter-control select {
+  width: 100%;
 }
 
 .quote-comment {

--- a/index.html
+++ b/index.html
@@ -150,6 +150,55 @@
             </button>
             <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
           </div>
+          <div class="site-nav__config">
+            <button
+              id="filter-config-button"
+              type="button"
+              class="btn-secondary btn-secondary--compact site-nav__config-toggle"
+              aria-haspopup="true"
+              aria-expanded="false"
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                <path
+                  d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <path
+                  d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09a1.65 1.65 0 0 0 1.51-1 1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33h.09A1.65 1.65 0 0 0 9 3.09V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51h.09a1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82v.09a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+              </svg>
+              <span class="sr-only">Configurer les filtres</span>
+            </button>
+            <div
+              id="filter-config-menu"
+              class="filter-config-menu"
+              role="menu"
+              aria-labelledby="filter-config-button"
+            >
+              <div class="filter-config-header">
+                <p class="text-sm font-semibold text-slate-900">Filtres supplémentaires</p>
+                <button id="filter-config-close" type="button" class="text-xs font-semibold text-blue-600 transition hover:text-blue-700">
+                  Fermer
+                </button>
+              </div>
+              <p class="filter-config-description">Sélectionnez les colonnes à afficher dans la recherche produit.</p>
+              <div
+                id="filter-config-options"
+                class="filter-config-options"
+                role="group"
+                aria-label="Sélection des filtres"
+              ></div>
+            </div>
+          </div>
           <button
             id="mobile-view-toggle"
             type="button"
@@ -297,6 +346,11 @@
                     <option value="">Toutes les unités</option>
                   </select>
                 </label>
+                <div
+                  id="dynamic-filters"
+                  class="flex w-full flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center"
+                  hidden
+                ></div>
               </div>
             </div>
           </header>


### PR DESCRIPTION
## Résumé
- ajoute un bouton de configuration dans la barre supérieure pour gérer les filtres produits supplémentaires et corrige le masquage du filtre de catégorie
- intègre la lecture des colonnes dynamiques du catalogue et leur activation dans l’interface de recherche produits

## Tests
- ⚠️ Aucun test automatisé (non applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e65ca326108329ab932c4d79b5768e