### PR TITLE
Ajoute un panneau de configuration pour les filtres de recherche

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -229,6 +229,178 @@ textarea {
   align-items: center;
   justify-content: flex-end;
   gap: 0.75rem;
+  position: relative;
+}
+
+.site-nav__filter-config {
+  position: relative;
+}
+
+.filter-config-menu {
+  position: absolute;
+  inset-inline-end: 0;
+  top: calc(100% + 0.75rem);
+  width: min(22rem, 92vw);
+  display: none;
+  flex-direction: column;
+  gap: 0.85rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  background: #fff;
+  box-shadow: 0 24px 60px -24px rgba(25, 63, 96, 0.45);
+  padding: 1.25rem;
+  z-index: 60;
+}
+
+.filter-config-menu[data-open='true'] {
+  display: flex;
+}
+
+.filter-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.filter-config-title {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.filter-config-close {
+  background: none;
+  border: none;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-primary);
+  cursor: pointer;
+  border-radius: 0.5rem;
+  padding: 0.35rem 0.5rem;
+}
+
+.filter-config-close:hover,
+.filter-config-close:focus-visible {
+  background: rgba(228, 30, 40, 0.08);
+  outline: none;
+}
+
+.filter-config-description {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-muted-strong);
+}
+
+.filter-config-options {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  max-height: 18rem;
+  overflow-y: auto;
+  padding-inline-end: 0.25rem;
+}
+
+.filter-config-option {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.75rem;
+  background: rgba(25, 63, 96, 0.05);
+  color: var(--color-secondary);
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.filter-config-option:hover,
+.filter-config-option:focus-within {
+  background: rgba(25, 63, 96, 0.12);
+}
+
+.filter-config-option.is-active {
+  background: rgba(228, 30, 40, 0.15);
+  color: var(--color-primary);
+}
+
+.filter-config-option.is-active .filter-config-option__meta {
+  color: var(--color-primary);
+}
+
+.filter-config-option input {
+  margin-top: 0.15rem;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+  accent-color: var(--color-primary);
+}
+
+.filter-config-option__label {
+  flex: 1;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.filter-config-option__meta {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-muted-strong);
+}
+
+.filter-config-empty {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--color-muted-strong);
+}
+
+.filter-config-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+  background: rgba(25, 63, 96, 0.12);
+  color: var(--color-secondary);
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.filter-config-button-label {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  line-height: 1.1;
+}
+
+.filter-config-button-title {
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--color-secondary);
+}
+
+.filter-config-button-helper {
+  font-size: 0.7rem;
+  color: var(--color-muted-strong);
+}
+
+.filter-config-button--active {
+  background: rgba(228, 30, 40, 0.12);
+  border-color: rgba(228, 30, 40, 0.35);
+  color: var(--color-primary);
+}
+
+.filter-config-button--active .filter-config-button-helper {
+  color: var(--color-primary);
+}
+
+.filter-config-button--active .filter-config-badge {
+  background: rgba(228, 30, 40, 0.18);
+  color: var(--color-primary);
 }
 
 .site-nav__tree {
@@ -975,6 +1147,11 @@ textarea {
   box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
   padding: 1rem;
   z-index: 30;
+}
+
+#category-filter-button {
+  position: relative;
+  z-index: 50;
 }
 
 .category-filter-menu[data-open='true'] {

--- a/index.html
+++ b/index.html
@@ -150,6 +150,49 @@
             </button>
             <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
           </div>
+          <div class="site-nav__filter-config">
+            <button
+              id="filter-config-button"
+              type="button"
+              class="btn-secondary"
+              aria-haspopup="true"
+              aria-expanded="false"
+              disabled
+            >
+              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                <path
+                  d="M10.325 4.317a1.75 1.75 0 0 1 3.35 0l.246.886a1.75 1.75 0 0 0 2.145 1.236l.905-.242a1.75 1.75 0 0 1 2.117 2.117l-.242.905a1.75 1.75 0 0 0 1.236 2.145l.886.246a1.75 1.75 0 0 1 0 3.35l-.886.246a1.75 1.75 0 0 0-1.236 2.145l.242.905a1.75 1.75 0 0 1-2.117 2.117l-.905-.242a1.75 1.75 0 0 0-2.145 1.236l-.246.886a1.75 1.75 0 0 1-3.35 0l-.246-.886a1.75 1.75 0 0 0-2.145-1.236l-.905.242a1.75 1.75 0 0 1-2.117-2.117l.242-.905a1.75 1.75 0 0 0-1.236-2.145l-.886-.246a1.75 1.75 0 0 1 0-3.35l.886-.246a1.75 1.75 0 0 0 1.236-2.145l-.242-.905a1.75 1.75 0 0 1 2.117-2.117l.905.242a1.75 1.75 0 0 0 2.145-1.236l.246-.886Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                />
+                <circle cx="12" cy="12" r="2.5" fill="none" stroke="currentColor" stroke-width="1.5" />
+              </svg>
+              <span class="filter-config-button-label">
+                <span class="filter-config-button-title">Filtres de recherche</span>
+                <span class="filter-config-button-helper">Champs supplémentaires</span>
+              </span>
+              <span id="filter-config-count" class="filter-config-badge">0</span>
+            </button>
+            <div
+              id="filter-config-menu"
+              class="filter-config-menu"
+              role="menu"
+              aria-labelledby="filter-config-button"
+            >
+              <div class="filter-config-header">
+                <p class="filter-config-title">Filtres disponibles</p>
+                <button id="filter-config-close" type="button" class="filter-config-close">Fermer</button>
+              </div>
+              <p class="filter-config-description">
+                Sélectionnez les colonnes à inclure dans la recherche produits.
+              </p>
+              <div id="filter-config-options" class="filter-config-options" role="group" aria-label="Filtres supplémentaires"></div>
+              <p id="filter-config-empty" class="filter-config-empty" hidden>Aucune colonne supplémentaire disponible.</p>
+            </div>
+          </div>
           <button
             id="mobile-view-toggle"
             type="button"


### PR DESCRIPTION
## Résumé
- remonte le bouton d'ouverture des filtres de catégories au-dessus de la grille produits
- ajoute un bouton de configuration dans la barre supérieure pour gérer les filtres issus des colonnes du CSV à partir de la 15ᵉ colonne
- adapte le chargement du catalogue et la recherche produit pour inclure dynamiquement les colonnes supplémentaires sélectionnées

## Tests
- Aucun test automatisé n'a été exécuté


------
https://chatgpt.com/codex/tasks/task_b_68e65ca326108329ab932c4d79b5768e