### PR TITLE
Réorganiser la navigation du devis et sécuriser l'envoi des commandes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -25,7 +25,7 @@
 }
 
 main {
-  margin-top: calc(var(--site-nav-height) + 1.5rem - 20px);
+  margin-top: 0;
 }
 
 ::selection {
@@ -122,20 +122,17 @@ textarea {
 }
 
 .site-nav {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(12px);
-  border-bottom: 3px solid var(--color-primary);
-  transition: transform 200ms ease, box-shadow 200ms ease;
+  background: var(--color-surface);
+  border: 1px solid rgba(25, 63, 96, 0.08);
+  border-radius: 1.25rem;
+  box-shadow: 0 20px 35px -28px rgba(25, 63, 96, 0.45);
+  padding: 1.25rem 1.5rem;
 }
 
-.site-nav[data-collapsed='true'] {
-  transform: translateY(calc(-100% + 1.8rem));
-  box-shadow: none;
-}
-
+.site-nav[data-collapsed='true'],
 .site-nav[data-collapsed='false'] {
-  transform: translateY(0);
-  box-shadow: 0 14px 40px -28px rgba(25, 63, 96, 0.55);
+  transform: none;
+  box-shadow: 0 20px 35px -28px rgba(25, 63, 96, 0.45);
 }
 
 .site-nav__identity[hidden] {
@@ -144,13 +141,14 @@ textarea {
 
 .site-nav__client {
   display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 63, 96, 0.15);
-  box-shadow: inset 0 1px 0 rgba(25, 63, 96, 0.08);
+  align-items: flex-start;
+  gap: 0.9rem;
+  padding: 0.75rem 1rem;
+  border-radius: 1rem;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(25, 63, 96, 0.12);
+  box-shadow: inset 0 1px 0 rgba(25, 63, 96, 0.06);
+  flex: 1 1 20rem;
 }
 
 .site-nav__client[hidden] {
@@ -159,8 +157,12 @@ textarea {
 
 .site-nav__client-text {
   display: grid;
-  gap: 0.15rem;
+  gap: 0.35rem;
   min-width: 14rem;
+}
+
+.site-nav__client-discount {
+  margin: 0.35rem 0 0;
 }
 
 .site-nav__client-name {
@@ -191,20 +193,49 @@ textarea {
 }
 
 .site-nav__inner {
-  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.site-nav__row {
   display: flex;
   flex-wrap: wrap;
-  align-items: center;
+  gap: 1rem;
+  align-items: stretch;
   justify-content: space-between;
-  gap: 0.75rem;
-  max-width: 120rem;
-  padding: 0.85rem 1.5rem;
+}
+
+.site-nav__row--primary {
+  gap: 1.25rem;
+}
+
+.site-nav__row--secondary {
+  align-items: center;
+}
+
+.site-nav__identity-group {
+  display: flex;
+  flex: 1 1 24rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: stretch;
+  justify-content: flex-end;
 }
 
 .site-nav__branding {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.site-nav__branding-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
 }
 
 .brand-logo {
@@ -215,6 +246,7 @@ textarea {
 }
 
 .brand-title {
+  margin: 0;
   font-family: var(--font-heading);
   font-weight: 700;
   font-size: 1.15rem;
@@ -231,11 +263,26 @@ textarea {
   gap: 0.75rem;
 }
 
+.site-nav__actions--secondary {
+  gap: 1.25rem;
+  justify-content: flex-end;
+  flex: 1 1 auto;
+}
+
+.site-nav__action-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+  justify-content: flex-end;
+}
+
 .site-nav__save-group {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 0.75rem;
+  flex: 1 1 22rem;
 }
 
 .save-name-field {
@@ -277,7 +324,6 @@ textarea {
   min-width: 10rem;
   flex: 0 1 12rem;
   width: min(100%, 14rem);
-  margin-left: auto;
 }
 
 .site-nav__tree-label {
@@ -304,7 +350,7 @@ textarea {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  margin-left: 0.5rem;
+  margin-left: 0;
   padding: 0.25rem 0.65rem;
   border-radius: 9999px;
   background: rgba(25, 63, 96, 0.08);
@@ -530,9 +576,9 @@ textarea {
 
 .catalogue-header {
   position: sticky;
-  top: calc(var(--site-nav-height) + 1rem);
-  z-index: 10;
-  backdrop-filter: blur(6px);
+  top: 0;
+  z-index: 40;
+  backdrop-filter: blur(8px);
   isolation: isolate;
   overflow: hidden;
 }
@@ -542,7 +588,7 @@ textarea {
   position: absolute;
   inset: 0;
   border-radius: inherit;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(255, 255, 255, 0.85));
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(255, 255, 255, 0.9));
   z-index: -1;
 }
 
@@ -598,6 +644,26 @@ textarea {
   background: linear-gradient(135deg, var(--color-primary), var(--color-primary-dark));
   color: #fff;
   box-shadow: 0 12px 24px -16px var(--color-primary);
+}
+
+.btn-primary:disabled,
+.btn-primary[aria-disabled='true'],
+.btn-secondary:disabled,
+.btn-secondary[aria-disabled='true'] {
+  opacity: 0.6;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.btn-primary:disabled,
+.btn-primary[aria-disabled='true'] {
+  background: linear-gradient(135deg, rgba(228, 30, 40, 0.65), rgba(196, 22, 32, 0.65));
+}
+
+.btn-secondary:disabled,
+.btn-secondary[aria-disabled='true'] {
+  background: rgba(25, 63, 96, 0.1);
+  color: var(--color-muted);
 }
 
 .btn-primary:hover,
@@ -734,6 +800,29 @@ textarea {
   display: flex;
   flex-direction: column;
   min-height: 0;
+}
+
+#quote-panel {
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  #quote-panel {
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+  }
+}
+
+#catalogue-panel {
+  gap: 1.5rem;
+}
+
+@media (min-width: 1024px) {
+  #catalogue-panel {
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+    padding-right: 0.5rem;
+  }
 }
 
 .gutter.gutter-horizontal {
@@ -958,7 +1047,7 @@ textarea {
   background: #fff;
   box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
   padding: 1rem;
-  z-index: 30;
+  z-index: 60;
 }
 
 .category-filter-menu[data-open='true'] {

--- a/index.html
+++ b/index.html
@@ -18,223 +18,7 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
-      <div class="site-nav__inner">
-        <div class="site-nav__branding">
-          <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
-          <p class="brand-title">ID GROUP</p>
-        </div>
-        <div class="site-nav__actions">
-          <form id="siret-form" class="site-nav__identity" autocomplete="off">
-            <label for="siret-input" class="site-nav__identity-label">SIRET</label>
-            <div class="site-nav__identity-controls">
-              <input
-                id="siret-input"
-                name="siret"
-                type="text"
-                inputmode="numeric"
-                maxlength="14"
-                placeholder="Numéro SIRET (14 chiffres)"
-                class="site-nav__identity-input"
-              />
-              <button
-                id="siret-submit"
-                type="submit"
-                class="btn-secondary btn-icon"
-                data-tooltip="Identifier le client"
-                aria-label="Identifier le client"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Identifier</span>
-              </button>
-            </div>
-            <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
-          </form>
-          <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
-            <div class="site-nav__client-text">
-              <p id="client-identity-name" class="site-nav__client-name"></p>
-              <p id="client-identity-meta" class="site-nav__client-meta"></p>
-              <p id="client-identity-register" class="site-nav__client-register">
-                <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
-                  >S'enregistrer comme nouveau client</a
-                >
-              </p>
-            </div>
-            <button
-              id="client-identity-reset"
-              type="button"
-              class="btn-secondary btn-secondary--compact btn-icon"
-              data-tooltip="Modifier l'identification"
-              aria-label="Modifier l'identification"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span class="sr-only">Modifier</span>
-            </button>
-          </div>
-          <div class="site-nav__save-group">
-            <label for="save-name" class="save-name-field">
-              <span>Proposition</span>
-              <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
-            </label>
-            <div class="site-nav__cart-actions">
-              <button
-                id="save-cart"
-                type="button"
-                class="btn-secondary btn-icon"
-                data-tooltip="Sauvegarder le panier"
-                aria-label="Sauvegarder le panier"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M9 3h6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M9 13h6v6H9z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Sauvegarder</span>
-              </button>
-              <button
-                id="restore-cart"
-                type="button"
-                class="btn-secondary btn-icon"
-                data-tooltip="Restaurer une sauvegarde"
-                aria-label="Restaurer une sauvegarde"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M4 4v6h6M20 20v-6h-6"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                  <path
-                    d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Restaurer</span>
-              </button>
-              <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-            </div>
-          </div>
-          <div class="discount-field" aria-live="polite">
-            <span>Remise</span>
-            <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
-          </div>
-          <button
-            id="generate-pdf"
-            class="btn-primary btn-icon"
-            data-tooltip="Imprimer le devis"
-            aria-label="Imprimer le devis"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <path
-                d="M7 13h10v8H7z"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-            </svg>
-            <span class="sr-only">Imprimer</span>
-          </button>
-          <button
-            id="submit-order"
-            class="btn-primary btn-icon"
-            data-tooltip="Passer commande"
-            aria-label="Passer commande"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M3 5h2l2 12h12l2-8H6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <circle cx="9" cy="19" r="1.5" fill="currentColor" />
-              <circle cx="18" cy="19" r="1.5" fill="currentColor" />
-            </svg>
-            <span class="sr-only">Passer commande</span>
-          </button>
-          <div class="site-nav__tree">
-            <label
-              for="catalogue-tree"
-              class="site-nav__tree-label icon-label"
-              data-tooltip="Sélectionner une catégorie"
-              aria-label="Sélectionner une catégorie"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 6h16M4 12h16M4 18h16"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sélectionner une catégorie</span>
-            </label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
-              <option value="">Sélectionner une catégorie ou un article</option>
-            </select>
-          </div>
-        </div>
-      </div>
-    </nav>
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
+    <main class="mx-auto w-full max-w-[120rem] px-4 pb-16 pt-12">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
           <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
@@ -301,6 +85,233 @@
           <div id="product-grid" class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>
         </section>
         <aside id="quote-panel" class="split-panel rounded-2xl bg-white p-6 shadow-lg brand-surface">
+          <nav class="site-nav" data-collapsed="false">
+            <div class="site-nav__inner">
+              <div class="site-nav__row site-nav__row--primary">
+                <div class="site-nav__branding">
+                  <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
+                  <div class="site-nav__branding-content">
+                    <p class="brand-title">ID GROUP</p>
+                    <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite">Production</span>
+                  </div>
+                </div>
+                <div class="site-nav__identity-group">
+                  <form id="siret-form" class="site-nav__identity" autocomplete="off">
+                    <label for="siret-input" class="site-nav__identity-label">SIRET</label>
+                    <div class="site-nav__identity-controls">
+                      <input
+                        id="siret-input"
+                        name="siret"
+                        type="text"
+                        inputmode="numeric"
+                        maxlength="14"
+                        placeholder="Numéro SIRET (14 chiffres)"
+                        class="site-nav__identity-input"
+                      />
+                      <button
+                        id="siret-submit"
+                        type="submit"
+                        class="btn-secondary btn-icon"
+                        data-tooltip="Identifier le client"
+                        aria-label="Identifier le client"
+                      >
+                        <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                          <path
+                            d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                        <span class="sr-only">Identifier</span>
+                      </button>
+                    </div>
+                    <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
+                  </form>
+                  <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
+                    <div class="site-nav__client-text">
+                      <p id="client-identity-name" class="site-nav__client-name"></p>
+                      <p id="client-identity-meta" class="site-nav__client-meta"></p>
+                      <div id="client-identity-discount" class="site-nav__client-discount discount-field" aria-live="polite">
+                        <span>Remise</span>
+                        <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
+                      </div>
+                      <p id="client-identity-register" class="site-nav__client-register">
+                        <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+                          >S'enregistrer comme nouveau client</a
+                        >
+                      </p>
+                    </div>
+                    <button
+                      id="client-identity-reset"
+                      type="button"
+                      class="btn-secondary btn-secondary--compact btn-icon"
+                      data-tooltip="Modifier l'identification"
+                      aria-label="Modifier l'identification"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      <span class="sr-only">Modifier</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="site-nav__row site-nav__row--secondary">
+                <div class="site-nav__save-group">
+                  <label for="save-name" class="save-name-field">
+                    <span>Proposition</span>
+                    <input id="save-name" type="text" maxlength="80" placeholder="Ex. Projet magasin" />
+                  </label>
+                  <div class="site-nav__cart-actions">
+                    <button
+                      id="save-cart"
+                      type="button"
+                      class="btn-secondary btn-icon"
+                      data-tooltip="Sauvegarder le panier"
+                      aria-label="Sauvegarder le panier"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M9 3h6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M9 13h6v6H9z"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                      <span class="sr-only">Sauvegarder</span>
+                    </button>
+                    <button
+                      id="restore-cart"
+                      type="button"
+                      class="btn-secondary btn-icon"
+                      data-tooltip="Restaurer une sauvegarde"
+                      aria-label="Restaurer une sauvegarde"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M4 4v6h6M20 20v-6h-6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                      <span class="sr-only">Restaurer</span>
+                    </button>
+                    <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+                  </div>
+                </div>
+                <div class="site-nav__actions site-nav__actions--secondary">
+                  <div class="site-nav__action-buttons">
+                    <button
+                      id="generate-pdf"
+                      class="btn-primary btn-icon"
+                      data-tooltip="Imprimer le devis"
+                      aria-label="Imprimer le devis"
+                      type="button"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M7 13h10v8H7z"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                      <span class="sr-only">Imprimer</span>
+                    </button>
+                    <button
+                      id="submit-order"
+                      class="btn-primary btn-icon"
+                      data-tooltip="Passer commande"
+                      aria-label="Passer commande"
+                      type="button"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M3 5h2l2 12h12l2-8H6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                        <circle cx="18" cy="19" r="1.5" fill="currentColor" />
+                      </svg>
+                      <span class="sr-only">Passer commande</span>
+                    </button>
+                  </div>
+                  <div class="site-nav__tree">
+                    <label
+                      for="catalogue-tree"
+                      class="site-nav__tree-label icon-label"
+                      data-tooltip="Sélectionner une catégorie"
+                      aria-label="Sélectionner une catégorie"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M4 6h16M4 12h16M4 18h16"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                      <span class="sr-only">Sélectionner une catégorie</span>
+                    </label>
+                    <select id="catalogue-tree" class="site-nav__tree-select">
+                      <option value="">Sélectionner une catégorie ou un article</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </nav>
           <footer class="quote-summary-panel border-b border-slate-200 pb-4">
             <dl class="space-y-2 text-sm text-slate-600">
               <div class="flex items-center justify-between">


### PR DESCRIPTION
## Résumé
- repositionne la barre de navigation dans la colonne devis avec une nouvelle organisation en deux lignes
- affiche la remise dans l’encart client, fixe l’entête du catalogue et corrige la superposition du filtre de catégories
- mémorise l’identifiant client fourni par le webhook, l’envoie lors de la commande et bloque l’envoi si le client n’est pas reconnu

## Tests
- non exécutés (application statique)


------
https://chatgpt.com/codex/tasks/task_b_68e756a4eb0c8329ad348e308d068116