### PR TITLE
Reorganize header layout and gate order submission

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -25,7 +25,7 @@
 }
 
 main {
-  margin-top: calc(var(--site-nav-height) + 1.5rem - 20px);
+  margin-top: 2rem;
 }
 
 ::selection {
@@ -122,20 +122,19 @@ textarea {
 }
 
 .site-nav {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(12px);
-  border-bottom: 3px solid var(--color-primary);
-  transition: transform 200ms ease, box-shadow 200ms ease;
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(14px);
+  border-bottom: 1px solid rgba(25, 63, 96, 0.12);
+  border-radius: 1.25rem 1.25rem 0 0;
+  box-shadow: 0 16px 40px -28px rgba(25, 63, 96, 0.45);
 }
 
-.site-nav[data-collapsed='true'] {
-  transform: translateY(calc(-100% + 1.8rem));
-  box-shadow: none;
-}
-
+.site-nav[data-collapsed='true'],
 .site-nav[data-collapsed='false'] {
-  transform: translateY(0);
-  box-shadow: 0 14px 40px -28px rgba(25, 63, 96, 0.55);
+  transform: none;
 }
 
 .site-nav__identity[hidden] {
@@ -190,21 +189,39 @@ textarea {
   text-decoration: underline;
 }
 
+.site-nav__client-discount {
+  margin: 0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--color-secondary);
+}
+
+.site-nav__client-discount[hidden] {
+  display: none;
+}
+
+.site-nav__client-discount span {
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
 .site-nav__inner {
-  margin: 0 auto;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  max-width: 120rem;
-  padding: 0.85rem 1.5rem;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem 1.75rem 1.25rem;
 }
 
 .site-nav__branding {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.site-nav__branding-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
 }
 
 .brand-logo {
@@ -222,23 +239,55 @@ textarea {
   white-space: nowrap;
 }
 
-.site-nav__actions {
+.site-nav__top-row {
   display: flex;
-  flex: 1;
+  flex-wrap: wrap;
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.site-nav__identity-group {
+  display: flex;
+  flex: 1 1 26rem;
+  gap: 1rem;
+  align-items: stretch;
+  justify-content: flex-end;
+}
+
+.site-nav__identity,
+.site-nav__client {
+  flex: 1 1 18rem;
+}
+
+.site-nav__bottom-row {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.site-nav__actions-group {
+  display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: flex-end;
-  gap: 0.75rem;
+  gap: 0.9rem;
+  width: 100%;
+}
+
+.site-nav__view-actions,
+.site-nav__primary-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
 }
 
 .site-nav__tree {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  min-width: 8rem;
-  flex: 0 1 10rem;
-  width: min(100%, 11rem);
-  margin-left: auto;
+  gap: 0.35rem;
+  padding: 0.75rem 1.75rem 1.25rem;
+  border-bottom: 1px solid rgba(25, 63, 96, 0.12);
+  background: rgba(246, 247, 250, 0.85);
 }
 
 .site-nav__tree-label {
@@ -275,6 +324,10 @@ textarea {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   border: 1px solid rgba(25, 63, 96, 0.12);
+}
+
+.webhook-mode-badge:empty {
+  display: none;
 }
 
 .webhook-mode-badge[data-mode='test'] {
@@ -627,6 +680,14 @@ textarea {
   outline-offset: 2px;
 }
 
+.btn-primary[disabled],
+.btn-secondary[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
 .btn-icon {
   width: 2.75rem;
   height: 2.75rem;
@@ -746,6 +807,16 @@ textarea {
   gap: 1.5rem;
 }
 
+#catalogue-panel {
+  position: relative;
+}
+
+.catalogue-header {
+  position: sticky;
+  top: 0;
+  z-index: 60;
+}
+
 .split-panel {
   display: flex;
   flex-direction: column;
@@ -854,6 +925,13 @@ textarea {
 .product-category-badge.is-muted {
   background-color: rgba(146, 151, 170, 0.2);
   color: var(--color-muted);
+}
+
+.quote-panel__content {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  padding: 1.5rem 1.75rem 1.75rem;
 }
 
 .product-card .product-actions {
@@ -974,7 +1052,7 @@ textarea {
   background: #fff;
   box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
   padding: 1rem;
-  z-index: 30;
+  z-index: 80;
 }
 
 .category-filter-menu[data-open='true'] {
@@ -1790,46 +1868,26 @@ body[data-viewport-mode='mobile'] .site-nav__inner {
   gap: 1rem;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__inner,
-body[data-viewport-mode='mobile'] .site-nav__inner {
-  display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  align-items: center;
-  width: 100%;
+body[data-viewport-mode='tablet'] .site-nav__top-row,
+body[data-viewport-mode='mobile'] .site-nav__top-row {
+  flex-direction: column;
+  align-items: stretch;
   gap: 0.75rem;
 }
 
-body[data-viewport-mode='mobile'] .site-nav__inner {
-  row-gap: 0.5rem;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__branding,
-body[data-viewport-mode='mobile'] .site-nav__branding {
-  grid-column: 1 / 2;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__actions,
-body[data-viewport-mode='mobile'] .site-nav__actions {
-  grid-column: 2 / 3;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  width: 100%;
-}
-
-body[data-viewport-mode='mobile'] .site-nav__actions {
-  row-gap: 0.35rem;
+body[data-viewport-mode='tablet'] .site-nav__identity-group,
+body[data-viewport-mode='mobile'] .site-nav__identity-group {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.75rem;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__identity,
 body[data-viewport-mode='mobile'] .site-nav__identity,
 body[data-viewport-mode='tablet'] .site-nav__client,
 body[data-viewport-mode='mobile'] .site-nav__client {
-  margin-right: auto;
-  flex: 0 1 15rem;
-  min-width: 9rem;
+  flex: 1 1 auto;
+  min-width: 100%;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__client,
@@ -1872,28 +1930,25 @@ body[data-viewport-mode='mobile'] .site-nav__identity-input {
   text-align: center;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__cart-actions,
-body[data-viewport-mode='mobile'] .site-nav__cart-actions {
-  flex-direction: row;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
+body[data-viewport-mode='tablet'] .site-nav__bottom-row,
+body[data-viewport-mode='mobile'] .site-nav__bottom-row {
+  justify-content: center;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__cart-actions .btn-secondary,
-body[data-viewport-mode='mobile'] .site-nav__cart-actions .btn-secondary,
-body[data-viewport-mode='tablet'] .site-nav__actions .btn-primary,
-body[data-viewport-mode='mobile'] .site-nav__actions .btn-primary,
-body[data-viewport-mode='tablet'] .site-nav__actions .btn-secondary,
-body[data-viewport-mode='mobile'] .site-nav__actions .btn-secondary,
-body[data-viewport-mode='tablet'] .viewport-toggle,
-body[data-viewport-mode='mobile'] .viewport-toggle,
-body[data-viewport-mode='tablet'] .discount-field,
-body[data-viewport-mode='mobile'] .discount-field,
-body[data-viewport-mode='tablet'] .site-nav__mobile-toggle,
-body[data-viewport-mode='mobile'] .site-nav__mobile-toggle {
-  flex: 0 0 auto;
-  width: auto;
+body[data-viewport-mode='tablet'] .site-nav__actions-group,
+body[data-viewport-mode='mobile'] .site-nav__actions-group {
+  justify-content: center;
+  gap: 0.65rem;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__view-actions,
+body[data-viewport-mode='mobile'] .site-nav__view-actions,
+body[data-viewport-mode='tablet'] .site-nav__primary-actions,
+body[data-viewport-mode='mobile'] .site-nav__primary-actions,
+body[data-viewport-mode='tablet'] .site-nav__cart-actions,
+body[data-viewport-mode='mobile'] .site-nav__cart-actions {
+  justify-content: center;
+  flex-wrap: wrap;
 }
 
 body[data-viewport-mode='tablet'] .viewport-toggle__button,
@@ -1978,7 +2033,7 @@ body[data-viewport-mode='tablet'][data-mobile-view='footer'] .site-nav__mobile-t
     align-items: flex-start;
   }
 
-  .site-nav__actions {
+  .site-nav__actions-group {
     width: 100%;
     justify-content: flex-start;
   }
@@ -1995,20 +2050,23 @@ body[data-viewport-mode='tablet'][data-mobile-view='footer'] .site-nav__mobile-t
     gap: 1rem;
   }
 
-  #catalogue-panel,
-  #quote-panel {
+  #catalogue-panel {
     padding: 1.5rem;
+  }
+
+  #quote-panel {
+    padding: 0;
   }
 }
 
 @media (max-width: 640px) {
-  .site-nav__actions {
+  .site-nav__actions-group {
     flex-direction: column;
     align-items: stretch;
     gap: 0.5rem;
   }
 
-  .site-nav__actions .btn-primary {
+  .site-nav__actions-group .btn-primary {
     width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -18,226 +18,7 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
-      <div class="site-nav__inner">
-        <div class="site-nav__branding">
-          <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
-          <p class="brand-title">ID GROUP</p>
-        </div>
-        <div class="site-nav__actions">
-          <form id="siret-form" class="site-nav__identity" autocomplete="off">
-            <label for="siret-input" class="site-nav__identity-label">SIRET</label>
-            <div class="site-nav__identity-controls">
-              <input
-                id="siret-input"
-                name="siret"
-                type="text"
-                inputmode="numeric"
-                maxlength="14"
-                placeholder="Numéro SIRET (14 chiffres)"
-                class="site-nav__identity-input"
-              />
-              <button
-                id="siret-submit"
-                type="submit"
-                class="btn-secondary btn-icon"
-                data-tooltip="Identifier le client"
-                aria-label="Identifier le client"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Identifier</span>
-              </button>
-            </div>
-            <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
-          </form>
-          <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
-            <div class="site-nav__client-text">
-              <p id="client-identity-name" class="site-nav__client-name"></p>
-              <p id="client-identity-meta" class="site-nav__client-meta"></p>
-              <p id="client-identity-register" class="site-nav__client-register">
-                <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
-                  >S'enregistrer comme nouveau client</a
-                >
-              </p>
-            </div>
-            <button
-              id="client-identity-reset"
-              type="button"
-              class="btn-secondary btn-secondary--compact btn-icon"
-              data-tooltip="Modifier l'identification"
-              aria-label="Modifier l'identification"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span class="sr-only">Modifier</span>
-            </button>
-          </div>
-          <div class="site-nav__cart-actions">
-            <button
-              id="save-cart"
-              type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Sauvegarder le panier"
-              aria-label="Sauvegarder le panier"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 3h6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 13h6v6H9z"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sauvegarder</span>
-            </button>
-            <button
-              id="restore-cart"
-              type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Restaurer une sauvegarde"
-              aria-label="Restaurer une sauvegarde"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 4v6h6M20 20v-6h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Restaurer</span>
-            </button>
-            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-          </div>
-          <button
-            id="mobile-view-toggle"
-            type="button"
-            class="btn-secondary btn-secondary--compact site-nav__mobile-toggle"
-            aria-pressed="false"
-          >
-            <span id="mobile-view-toggle-label" class="site-nav__mobile-toggle-label">Voir le pied de page</span>
-          </button>
-          <div class="viewport-toggle" data-mode="desktop">
-            <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
-              <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
-                <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
-                <rect
-                  data-role="viewport-stand"
-                  class="viewport-toggle__icon-stand"
-                  x="12"
-                  y="26"
-                  width="8"
-                  height="2"
-                  rx="1"
-                  ry="1"
-                />
-              </svg>
-              <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
-            </button>
-          </div>
-          <div class="discount-field" aria-live="polite">
-            <span>Remise</span>
-            <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
-          </div>
-          <button
-            id="generate-pdf"
-            class="btn-primary btn-icon"
-            data-tooltip="Imprimer le devis"
-            aria-label="Imprimer le devis"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <path
-                d="M7 13h10v8H7z"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-            </svg>
-            <span class="sr-only">Imprimer</span>
-          </button>
-          <button
-            id="submit-order"
-            class="btn-primary btn-icon"
-            data-tooltip="Passer commande"
-            aria-label="Passer commande"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M3 5h2l2 12h12l2-8H6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <circle cx="9" cy="19" r="1.5" fill="currentColor" />
-              <circle cx="18" cy="19" r="1.5" fill="currentColor" />
-            </svg>
-            <span class="sr-only">Passer commande</span>
-          </button>
-          <div class="site-nav__tree">
-            <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
-              <option value="">Sélectionner une catégorie ou un article</option>
-            </select>
-          </div>
-        </div>
-      </div>
-    </nav>
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
+    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-10">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
           <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
@@ -303,13 +84,247 @@
           <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
           <div id="product-grid" class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>
         </section>
-        <aside id="quote-panel" class="split-panel rounded-2xl bg-white p-6 shadow-lg brand-surface">
-          <footer class="quote-summary-panel border-b border-slate-200 pb-4">
-            <dl class="space-y-2 text-sm text-slate-600">
-              <div class="flex items-center justify-between">
-                <dt>Total HT produits</dt>
-                <dd id="summary-products" class="font-semibold text-slate-900">0,00 €</dd>
+        <aside id="quote-panel" class="split-panel rounded-2xl bg-white p-0 shadow-lg brand-surface">
+          <nav class="site-nav" data-collapsed="false">
+            <div class="site-nav__inner">
+              <div class="site-nav__top-row">
+                <div class="site-nav__branding">
+                  <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
+                  <div class="site-nav__branding-text">
+                    <p class="brand-title">ID GROUP</p>
+                    <span id="webhook-mode-badge" class="webhook-mode-badge" aria-live="polite"></span>
+                  </div>
+                </div>
+                <div class="site-nav__identity-group">
+                  <form id="siret-form" class="site-nav__identity" autocomplete="off">
+                    <label for="siret-input" class="site-nav__identity-label">SIRET</label>
+                    <div class="site-nav__identity-controls">
+                      <input
+                        id="siret-input"
+                        name="siret"
+                        type="text"
+                        inputmode="numeric"
+                        maxlength="14"
+                        placeholder="Numéro SIRET (14 chiffres)"
+                        class="site-nav__identity-input"
+                      />
+                      <button
+                        id="siret-submit"
+                        type="submit"
+                        class="btn-secondary btn-icon"
+                        data-tooltip="Identifier le client"
+                        aria-label="Identifier le client"
+                      >
+                        <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                          <path
+                            d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                        <span class="sr-only">Identifier</span>
+                      </button>
+                    </div>
+                    <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
+                  </form>
+                  <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
+                    <div class="site-nav__client-text">
+                      <p id="client-identity-name" class="site-nav__client-name"></p>
+                      <p id="client-identity-meta" class="site-nav__client-meta"></p>
+                      <p id="client-identity-discount" class="site-nav__client-discount" hidden>
+                        Remise client : <span id="header-discount">0&nbsp;%</span>
+                      </p>
+                      <p id="client-identity-register" class="site-nav__client-register">
+                        <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+                          >S'enregistrer comme nouveau client</a
+                        >
+                      </p>
+                    </div>
+                    <button
+                      id="client-identity-reset"
+                      type="button"
+                      class="btn-secondary btn-secondary--compact btn-icon"
+                      data-tooltip="Modifier l'identification"
+                      aria-label="Modifier l'identification"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      <span class="sr-only">Modifier</span>
+                    </button>
+                  </div>
+                </div>
               </div>
+              <div class="site-nav__bottom-row">
+                <div class="site-nav__actions-group">
+                  <div class="site-nav__cart-actions">
+                    <button
+                      id="save-cart"
+                      type="button"
+                      class="btn-secondary btn-icon"
+                      data-tooltip="Sauvegarder le panier"
+                      aria-label="Sauvegarder le panier"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M9 3h6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M9 13h6v6H9z"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                      <span class="sr-only">Sauvegarder</span>
+                    </button>
+                    <button
+                      id="restore-cart"
+                      type="button"
+                      class="btn-secondary btn-icon"
+                      data-tooltip="Restaurer une sauvegarde"
+                      aria-label="Restaurer une sauvegarde"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M4 4v6h6M20 20v-6h-6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                      <span class="sr-only">Restaurer</span>
+                    </button>
+                    <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+                  </div>
+                  <div class="site-nav__view-actions">
+                    <div class="viewport-toggle" data-mode="desktop">
+                      <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
+                        <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
+                          <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
+                          <rect
+                            data-role="viewport-stand"
+                            class="viewport-toggle__icon-stand"
+                            x="12"
+                            y="26"
+                            width="8"
+                            height="2"
+                            rx="1"
+                            ry="1"
+                          />
+                        </svg>
+                        <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
+                      </button>
+                    </div>
+                    <button
+                      id="mobile-view-toggle"
+                      type="button"
+                      class="btn-secondary btn-secondary--compact site-nav__mobile-toggle"
+                      aria-pressed="false"
+                    >
+                      <span id="mobile-view-toggle-label" class="site-nav__mobile-toggle-label">Voir le pied de page</span>
+                    </button>
+                  </div>
+                  <div class="site-nav__primary-actions">
+                    <button
+                      id="generate-pdf"
+                      class="btn-primary btn-icon"
+                      data-tooltip="Imprimer le devis"
+                      aria-label="Imprimer le devis"
+                      type="button"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <path
+                          d="M7 13h10v8H7z"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                      </svg>
+                      <span class="sr-only">Imprimer</span>
+                    </button>
+                    <button
+                      id="submit-order"
+                      class="btn-primary btn-icon"
+                      data-tooltip="Passer commande"
+                      aria-label="Passer commande"
+                      type="button"
+                      disabled
+                      aria-disabled="true"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M3 5h2l2 12h12l2-8H6"
+                          fill="none"
+                          stroke="currentColor"
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="1.5"
+                        />
+                        <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                        <circle cx="18" cy="19" r="1.5" fill="currentColor" />
+                      </svg>
+                      <span class="sr-only">Passer commande</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </nav>
+          <div class="site-nav__tree">
+            <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
+            <select id="catalogue-tree" class="site-nav__tree-select">
+              <option value="">Sélectionner une catégorie ou un article</option>
+            </select>
+          </div>
+          <div class="quote-panel__content">
+            <footer class="quote-summary-panel border-b border-slate-200 pb-4">
+              <dl class="space-y-2 text-sm text-slate-600">
+                <div class="flex items-center justify-between">
+                  <dt>Total HT produits</dt>
+                  <dd id="summary-products" class="font-semibold text-slate-900">0,00 €</dd>
+                </div>
               <div class="flex items-center justify-between gap-3">
                 <dt class="flex-1">Remise (%)</dt>
                 <dd class="flex items-center gap-2">
@@ -337,25 +352,26 @@
                 <dd id="summary-total">0,00 €</dd>
               </div>
             </dl>
-          </footer>
-          <header class="mt-4 flex items-start justify-between gap-2">
-            <div>
-              <h2 class="text-xl font-semibold text-slate-900">Devis en cours</h2>
-              <p class="text-sm text-slate-500">Ajustez les quantités et vérifiez les totaux en temps réel.</p>
+            </footer>
+            <header class="mt-4 flex items-start justify-between gap-2">
+              <div>
+                <h2 class="text-xl font-semibold text-slate-900">Devis en cours</h2>
+                <p class="text-sm text-slate-500">Ajustez les quantités et vérifiez les totaux en temps réel.</p>
+              </div>
+            </header>
+            <div id="quote-empty" class="mt-4 flex flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-10 w-10 text-slate-300" fill="none" stroke="currentColor" stroke-width="1.5">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5v-12A1.5 1.5 0 0 0 19.5 4.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
+              </svg>
+              <p>Aucun article n'a encore été ajouté. Utilisez le bouton « Ajouter au devis » sur un produit.</p>
             </div>
-          </header>
-          <div id="quote-empty" class="mt-4 flex flex-1 flex-col items-center justify-center gap-3 rounded-xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-500">
-            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="h-10 w-10 text-slate-300" fill="none" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
-              <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5v-12A1.5 1.5 0 0 0 19.5 4.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
-            </svg>
-            <p>Aucun article n'a encore été ajouté. Utilisez le bouton « Ajouter au devis » sur un produit.</p>
-          </div>
-          <div id="quote-list" class="mt-4 hidden flex-1 space-y-4 overflow-y-auto pr-1"></div>
-          <div class="mt-6 space-y-4">
-            <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
-              <label for="general-comment" class="text-sm font-medium text-slate-700">Commentaire général</label>
-              <textarea id="general-comment" class="general-comment mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez un message qui apparaîtra sur le devis généré..."></textarea>
+            <div id="quote-list" class="mt-4 hidden flex-1 space-y-4 overflow-y-auto pr-1"></div>
+            <div class="mt-6 space-y-4">
+              <div class="rounded-xl border border-slate-200 bg-slate-50 p-4">
+                <label for="general-comment" class="text-sm font-medium text-slate-700">Commentaire général</label>
+                <textarea id="general-comment" class="general-comment mt-2 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20" placeholder="Ajoutez un message qui apparaîtra sur le devis généré..."></textarea>
+              </div>
             </div>
           </div>
         </aside>


### PR DESCRIPTION
## Summary
- move the navigation controls into the quote panel, showing client identity and the discount in the right column header
- refresh styles for the right pane, including a sticky catalogue header and a visible category filter menu
- require a recognized client ID from the webhook before enabling checkout and forward it with order submissions

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e75cc98538832999989043f1f1aa65