### PR TITLE
Réorganise le menu droit et sécurise la commande

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,7 +14,7 @@
   --color-muted: #9297aa;
   --color-muted-strong: #4a5364;
   --color-border: #a5b7c6;
-  --site-nav-height: 4.75rem;
+  --site-nav-height: 0rem;
 }
 
 .site-body {
@@ -121,21 +121,17 @@ textarea {
   border-radius: 0.55rem !important;
 }
 
+
 .site-nav {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(12px);
-  border-bottom: 3px solid var(--color-primary);
-  transition: transform 200ms ease, box-shadow 200ms ease;
+  position: static;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
 }
 
-.site-nav[data-collapsed='true'] {
-  transform: translateY(calc(-100% + 1.8rem));
-  box-shadow: none;
-}
-
+.site-nav[data-collapsed='true'],
 .site-nav[data-collapsed='false'] {
-  transform: translateY(0);
-  box-shadow: 0 14px 40px -28px rgba(25, 63, 96, 0.55);
+  transform: none;
+  box-shadow: none;
 }
 
 .site-nav__identity[hidden] {
@@ -144,11 +140,13 @@ textarea {
 
 .site-nav__client {
   display: flex;
-  align-items: center;
+  align-items: stretch;
+  justify-content: space-between;
+  flex-wrap: wrap;
   gap: 0.75rem;
-  padding: 0.35rem 0.6rem;
+  padding: 0.75rem 0.9rem;
   border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.95);
   border: 1px solid rgba(25, 63, 96, 0.15);
   box-shadow: inset 0 1px 0 rgba(25, 63, 96, 0.08);
 }
@@ -157,10 +155,26 @@ textarea {
   display: none !important;
 }
 
+.site-nav__client-details {
+  flex: 1 1 16rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-start;
+}
+
 .site-nav__client-text {
   display: grid;
-  gap: 0.15rem;
-  min-width: 14rem;
+  gap: 0.25rem;
+  min-width: 12rem;
+  flex: 1 1 12rem;
+}
+
+.site-nav__client-discount {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
 }
 
 .site-nav__client-name {
@@ -191,20 +205,49 @@ textarea {
 }
 
 .site-nav__inner {
-  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.site-nav__row {
   display: flex;
   flex-wrap: wrap;
+  gap: 1rem;
   align-items: center;
+}
+
+.site-nav__row--identity {
   justify-content: space-between;
-  gap: 0.75rem;
-  max-width: 120rem;
-  padding: 0.85rem 1.5rem;
+}
+
+.site-nav__row--actions {
+  justify-content: flex-start;
 }
 
 .site-nav__branding {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.site-nav__identity-wrapper {
+  flex: 1 1 18rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.site-nav__identity {
+  width: 100%;
+}
+
+.site-nav__action-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  width: 100%;
 }
 
 .brand-logo {
@@ -222,23 +265,11 @@ textarea {
   white-space: nowrap;
 }
 
-.site-nav__actions {
-  display: flex;
-  flex: 1;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.75rem;
-}
-
 .site-nav__tree {
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  min-width: 8rem;
-  flex: 0 1 10rem;
-  width: min(100%, 11rem);
-  margin-left: auto;
+  width: 100%;
 }
 
 .site-nav__tree-label {
@@ -361,17 +392,6 @@ textarea {
 .site-nav__identity button[disabled] {
   opacity: 0.6;
   cursor: progress;
-}
-
-.site-nav__cart-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  flex-wrap: wrap;
-}
-
-.site-nav__cart-actions .btn-secondary {
-  white-space: nowrap;
 }
 
 .site-nav__mobile-toggle {
@@ -546,11 +566,11 @@ textarea {
 
 .catalogue-header {
   position: sticky;
-  top: calc(var(--site-nav-height) + 1rem);
-  z-index: 10;
+  top: 1.5rem;
+  z-index: 30;
   backdrop-filter: blur(6px);
   isolation: isolate;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .catalogue-header::before {
@@ -637,6 +657,22 @@ textarea {
 .btn-icon .icon {
   width: 1.25rem;
   height: 1.25rem;
+}
+
+.btn-primary[disabled],
+.btn-secondary[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.btn-primary[disabled]:hover,
+.btn-primary[disabled]:focus-visible,
+.btn-secondary[disabled]:hover,
+.btn-secondary[disabled]:focus-visible {
+  transform: none;
+  box-shadow: none;
 }
 
 [data-tooltip] {
@@ -1783,127 +1819,49 @@ textarea {
   gap: 0.6rem;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__inner,
-body[data-viewport-mode='mobile'] .site-nav__inner {
-  flex-direction: column;
-  align-items: stretch;
-  gap: 1rem;
+body[data-viewport-mode='tablet'] .site-nav,
+body[data-viewport-mode='mobile'] .site-nav {
+  position: static;
+  margin-bottom: 1rem;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__inner,
-body[data-viewport-mode='mobile'] .site-nav__inner {
-  display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  align-items: center;
-  width: 100%;
+body[data-viewport-mode='tablet'] .site-nav__row--identity,
+body[data-viewport-mode='mobile'] .site-nav__row--identity {
+  flex-direction: column;
+  align-items: stretch;
   gap: 0.75rem;
 }
 
-body[data-viewport-mode='mobile'] .site-nav__inner {
-  row-gap: 0.5rem;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__branding,
-body[data-viewport-mode='mobile'] .site-nav__branding {
-  grid-column: 1 / 2;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__actions,
-body[data-viewport-mode='mobile'] .site-nav__actions {
-  grid-column: 2 / 3;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
+body[data-viewport-mode='tablet'] .site-nav__identity-wrapper,
+body[data-viewport-mode='mobile'] .site-nav__identity-wrapper {
   width: 100%;
-}
-
-body[data-viewport-mode='mobile'] .site-nav__actions {
-  row-gap: 0.35rem;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__identity,
-body[data-viewport-mode='mobile'] .site-nav__identity,
-body[data-viewport-mode='tablet'] .site-nav__client,
-body[data-viewport-mode='mobile'] .site-nav__client {
-  margin-right: auto;
-  flex: 0 1 15rem;
-  min-width: 9rem;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__client,
 body[data-viewport-mode='mobile'] .site-nav__client {
-  order: -1;
-  padding: 0.5rem 0.65rem;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+body[data-viewport-mode='tablet'] .site-nav__client-details,
+body[data-viewport-mode='mobile'] .site-nav__client-details {
+  flex-direction: column;
+  align-items: stretch;
   gap: 0.5rem;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__identity,
-body[data-viewport-mode='mobile'] .site-nav__identity {
-  padding: 0;
-  background: transparent;
-  border: none;
-  box-shadow: none;
+body[data-viewport-mode='tablet'] .site-nav__client-discount,
+body[data-viewport-mode='mobile'] .site-nav__client-discount {
+  justify-content: space-between;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__identity-controls,
-body[data-viewport-mode='mobile'] .site-nav__identity-controls {
-  display: block;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__identity-label,
-body[data-viewport-mode='tablet'] .site-nav__identity-feedback,
-body[data-viewport-mode='tablet'] #siret-submit,
-body[data-viewport-mode='mobile'] .site-nav__identity-label,
-body[data-viewport-mode='mobile'] .site-nav__identity-feedback,
-body[data-viewport-mode='mobile'] #siret-submit {
-  display: none;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__identity-input,
-body[data-viewport-mode='mobile'] .site-nav__identity-input {
-  width: 100%;
-  min-width: 0;
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.65rem;
-  font-size: 0.9rem;
-  letter-spacing: 0.08em;
-  text-align: center;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__cart-actions,
-body[data-viewport-mode='mobile'] .site-nav__cart-actions {
-  flex-direction: row;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__cart-actions .btn-secondary,
-body[data-viewport-mode='mobile'] .site-nav__cart-actions .btn-secondary,
-body[data-viewport-mode='tablet'] .site-nav__actions .btn-primary,
-body[data-viewport-mode='mobile'] .site-nav__actions .btn-primary,
-body[data-viewport-mode='tablet'] .site-nav__actions .btn-secondary,
-body[data-viewport-mode='mobile'] .site-nav__actions .btn-secondary,
-body[data-viewport-mode='tablet'] .viewport-toggle,
-body[data-viewport-mode='mobile'] .viewport-toggle,
-body[data-viewport-mode='tablet'] .discount-field,
-body[data-viewport-mode='mobile'] .discount-field,
-body[data-viewport-mode='tablet'] .site-nav__mobile-toggle,
-body[data-viewport-mode='mobile'] .site-nav__mobile-toggle {
-  flex: 0 0 auto;
-  width: auto;
-}
-
-body[data-viewport-mode='tablet'] .viewport-toggle__button,
-body[data-viewport-mode='mobile'] .viewport-toggle__button {
+body[data-viewport-mode='tablet'] .site-nav__action-group,
+body[data-viewport-mode='mobile'] .site-nav__action-group {
   justify-content: center;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__mobile-toggle,
-body[data-viewport-mode='mobile'] .site-nav__mobile-toggle {
-  display: inline-flex;
+body[data-viewport-mode='mobile'] .site-nav__action-group {
+  gap: 0.75rem;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__tree,
@@ -1975,20 +1933,17 @@ body[data-viewport-mode='tablet'][data-mobile-view='footer'] .site-nav__mobile-t
 @media (max-width: 768px) {
   .site-nav__inner {
     flex-direction: column;
-    align-items: flex-start;
+    align-items: stretch;
   }
 
-  .site-nav__actions {
-    width: 100%;
-    justify-content: flex-start;
-  }
-
-  .site-nav__identity,
-  .site-nav__cart-actions,
+  .site-nav__row--identity,
+  .site-nav__action-group,
   .site-nav__tree {
     width: 100%;
-    flex: 1 1 100%;
-    margin-left: 0;
+  }
+
+  .site-nav__action-group {
+    justify-content: center;
   }
 
   #main-layout {
@@ -2002,22 +1957,17 @@ body[data-viewport-mode='tablet'][data-mobile-view='footer'] .site-nav__mobile-t
 }
 
 @media (max-width: 640px) {
-  .site-nav__actions {
+  .site-nav__action-group {
     flex-direction: column;
     align-items: stretch;
     gap: 0.5rem;
   }
 
-  .site-nav__actions .btn-primary {
-    width: 100%;
-  }
-
-  .site-nav__cart-actions {
-    flex-direction: column;
-    align-items: stretch;
-  }
-
-  .site-nav__cart-actions .btn-secondary {
+  .site-nav__action-group .btn-primary,
+  .site-nav__action-group .btn-secondary,
+  .site-nav__action-group .viewport-toggle,
+  .site-nav__action-group .site-nav__mobile-toggle,
+  .site-nav__action-group #generate-pdf {
     width: 100%;
   }
 

--- a/index.html
+++ b/index.html
@@ -18,225 +18,6 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
-      <div class="site-nav__inner">
-        <div class="site-nav__branding">
-          <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
-          <p class="brand-title">ID GROUP</p>
-        </div>
-        <div class="site-nav__actions">
-          <form id="siret-form" class="site-nav__identity" autocomplete="off">
-            <label for="siret-input" class="site-nav__identity-label">SIRET</label>
-            <div class="site-nav__identity-controls">
-              <input
-                id="siret-input"
-                name="siret"
-                type="text"
-                inputmode="numeric"
-                maxlength="14"
-                placeholder="Numéro SIRET (14 chiffres)"
-                class="site-nav__identity-input"
-              />
-              <button
-                id="siret-submit"
-                type="submit"
-                class="btn-secondary btn-icon"
-                data-tooltip="Identifier le client"
-                aria-label="Identifier le client"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Identifier</span>
-              </button>
-            </div>
-            <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
-          </form>
-          <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
-            <div class="site-nav__client-text">
-              <p id="client-identity-name" class="site-nav__client-name"></p>
-              <p id="client-identity-meta" class="site-nav__client-meta"></p>
-              <p id="client-identity-register" class="site-nav__client-register">
-                <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
-                  >S'enregistrer comme nouveau client</a
-                >
-              </p>
-            </div>
-            <button
-              id="client-identity-reset"
-              type="button"
-              class="btn-secondary btn-secondary--compact btn-icon"
-              data-tooltip="Modifier l'identification"
-              aria-label="Modifier l'identification"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span class="sr-only">Modifier</span>
-            </button>
-          </div>
-          <div class="site-nav__cart-actions">
-            <button
-              id="save-cart"
-              type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Sauvegarder le panier"
-              aria-label="Sauvegarder le panier"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 3h6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 13h6v6H9z"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sauvegarder</span>
-            </button>
-            <button
-              id="restore-cart"
-              type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Restaurer une sauvegarde"
-              aria-label="Restaurer une sauvegarde"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 4v6h6M20 20v-6h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Restaurer</span>
-            </button>
-            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-          </div>
-          <button
-            id="mobile-view-toggle"
-            type="button"
-            class="btn-secondary btn-secondary--compact site-nav__mobile-toggle"
-            aria-pressed="false"
-          >
-            <span id="mobile-view-toggle-label" class="site-nav__mobile-toggle-label">Voir le pied de page</span>
-          </button>
-          <div class="viewport-toggle" data-mode="desktop">
-            <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
-              <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
-                <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
-                <rect
-                  data-role="viewport-stand"
-                  class="viewport-toggle__icon-stand"
-                  x="12"
-                  y="26"
-                  width="8"
-                  height="2"
-                  rx="1"
-                  ry="1"
-                />
-              </svg>
-              <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
-            </button>
-          </div>
-          <div class="discount-field" aria-live="polite">
-            <span>Remise</span>
-            <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
-          </div>
-          <button
-            id="generate-pdf"
-            class="btn-primary btn-icon"
-            data-tooltip="Imprimer le devis"
-            aria-label="Imprimer le devis"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <path
-                d="M7 13h10v8H7z"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-            </svg>
-            <span class="sr-only">Imprimer</span>
-          </button>
-          <button
-            id="submit-order"
-            class="btn-primary btn-icon"
-            data-tooltip="Passer commande"
-            aria-label="Passer commande"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M3 5h2l2 12h12l2-8H6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <circle cx="9" cy="19" r="1.5" fill="currentColor" />
-              <circle cx="18" cy="19" r="1.5" fill="currentColor" />
-            </svg>
-            <span class="sr-only">Passer commande</span>
-          </button>
-          <div class="site-nav__tree">
-            <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
-              <option value="">Sélectionner une catégorie ou un article</option>
-            </select>
-          </div>
-        </div>
-      </div>
-    </nav>
     <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
@@ -304,6 +85,231 @@
           <div id="product-grid" class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>
         </section>
         <aside id="quote-panel" class="split-panel rounded-2xl bg-white p-6 shadow-lg brand-surface">
+          <nav class="site-nav" data-collapsed="false" aria-label="Identification client et actions du panier">
+            <div class="site-nav__inner">
+              <div class="site-nav__row site-nav__row--identity">
+                <div class="site-nav__branding">
+                  <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
+                  <p class="brand-title">ID GROUP</p>
+                </div>
+                <div class="site-nav__identity-wrapper">
+                  <form id="siret-form" class="site-nav__identity" autocomplete="off">
+                    <label for="siret-input" class="site-nav__identity-label">SIRET</label>
+                    <div class="site-nav__identity-controls">
+                      <input
+                        id="siret-input"
+                        name="siret"
+                        type="text"
+                        inputmode="numeric"
+                        maxlength="14"
+                        placeholder="Numéro SIRET (14 chiffres)"
+                        class="site-nav__identity-input"
+                      />
+                      <button
+                        id="siret-submit"
+                        type="submit"
+                        class="btn-secondary btn-icon"
+                        data-tooltip="Identifier le client"
+                        aria-label="Identifier le client"
+                      >
+                        <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                          <path
+                            d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                        <span class="sr-only">Identifier</span>
+                      </button>
+                    </div>
+                    <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
+                  </form>
+                  <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
+                    <div class="site-nav__client-details">
+                      <div class="site-nav__client-text">
+                        <p id="client-identity-name" class="site-nav__client-name"></p>
+                        <p id="client-identity-meta" class="site-nav__client-meta"></p>
+                        <p id="client-identity-register" class="site-nav__client-register">
+                          <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+                            >S'enregistrer comme nouveau client</a
+                          >
+                        </p>
+                      </div>
+                      <div class="discount-field site-nav__client-discount" aria-live="polite">
+                        <span>Remise</span>
+                        <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
+                      </div>
+                    </div>
+                    <button
+                      id="client-identity-reset"
+                      type="button"
+                      class="btn-secondary btn-secondary--compact btn-icon"
+                      data-tooltip="Modifier l'identification"
+                      aria-label="Modifier l'identification"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      <span class="sr-only">Modifier</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="site-nav__row site-nav__row--actions">
+                <div class="site-nav__action-group">
+                  <button
+                    id="save-cart"
+                    type="button"
+                    class="btn-secondary btn-icon"
+                    data-tooltip="Sauvegarder le panier"
+                    aria-label="Sauvegarder le panier"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M9 3h6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M9 13h6v6H9z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                    <span class="sr-only">Sauvegarder</span>
+                  </button>
+                  <button
+                    id="restore-cart"
+                    type="button"
+                    class="btn-secondary btn-icon"
+                    data-tooltip="Restaurer une sauvegarde"
+                    aria-label="Restaurer une sauvegarde"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M4 4v6h6M20 20v-6h-6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                    <span class="sr-only">Restaurer</span>
+                  </button>
+                  <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+                  <button
+                    id="mobile-view-toggle"
+                    type="button"
+                    class="btn-secondary btn-secondary--compact site-nav__mobile-toggle"
+                    aria-pressed="false"
+                  >
+                    <span id="mobile-view-toggle-label" class="site-nav__mobile-toggle-label">Voir le pied de page</span>
+                  </button>
+                  <div class="viewport-toggle" data-mode="desktop">
+                    <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
+                      <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
+                        <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
+                        <rect
+                          data-role="viewport-stand"
+                          class="viewport-toggle__icon-stand"
+                          x="12"
+                          y="26"
+                          width="8"
+                          height="2"
+                          rx="1"
+                          ry="1"
+                        />
+                      </svg>
+                      <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
+                    </button>
+                  </div>
+                  <button
+                    id="generate-pdf"
+                    class="btn-secondary btn-icon"
+                    data-tooltip="Imprimer le devis"
+                    aria-label="Imprimer le devis"
+                    type="button"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M7 13h10v8H7z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                    <span class="sr-only">Imprimer</span>
+                  </button>
+                  <button
+                    id="submit-order"
+                    class="btn-primary btn-icon"
+                    data-tooltip="Passer commande"
+                    aria-label="Passer commande"
+                    type="button"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M3 5h2l2 12h12l2-8H6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                      <circle cx="18" cy="19" r="1.5" fill="currentColor" />
+                    </svg>
+                    <span class="sr-only">Passer commande</span>
+                  </button>
+                </div>
+              </div>
+              <div class="site-nav__tree">
+                <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
+                <select id="catalogue-tree" class="site-nav__tree-select">
+                  <option value="">Sélectionner une catégorie ou un article</option>
+                </select>
+              </div>
+            </div>
+          </nav>
           <footer class="quote-summary-panel border-b border-slate-200 pb-4">
             <dl class="space-y-2 text-sm text-slate-600">
               <div class="flex items-center justify-between">


### PR DESCRIPTION
## Résumé
- replace le menu supérieur dans la colonne devis avec une présentation en deux lignes et remise intégrée à l'identification client
- ajuste le style pour le nouveau positionnement, rend l'entête catalogue visible et fait passer la remise via le récapitulatif client
- mémorise l'identifiant client du webhook et bloque l'envoi de commande tant que le client n'est pas reconnu, en envoyant cet identifiant au webhook de commande

## Tests
- Non exécutés (application front statique)


------
https://chatgpt.com/codex/tasks/task_b_68e75cc98538832999989043f1f1aa65