### PR TITLE
Réorganise la navigation et sécurise la commande

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -14,7 +14,7 @@
   --color-muted: #9297aa;
   --color-muted-strong: #4a5364;
   --color-border: #a5b7c6;
-  --site-nav-height: 4.75rem;
+  --site-nav-height: 9.5rem;
 }
 
 .site-body {
@@ -25,7 +25,7 @@
 }
 
 main {
-  margin-top: calc(var(--site-nav-height) + 1.5rem - 20px);
+  margin-top: 0;
 }
 
 ::selection {
@@ -122,20 +122,23 @@ textarea {
 }
 
 .site-nav {
-  background: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(12px);
-  border-bottom: 3px solid var(--color-primary);
-  transition: transform 200ms ease, box-shadow 200ms ease;
+  position: sticky;
+  top: 0;
+  z-index: 5;
+  display: block;
+  width: 100%;
+  background: rgba(255, 255, 255, 0.98);
+  border: 1px solid rgba(25, 63, 96, 0.1);
+  border-radius: 1.15rem;
+  box-shadow: 0 18px 44px -30px rgba(25, 63, 96, 0.55);
+  padding: 1.35rem 1.5rem;
+  margin-bottom: 1.5rem;
 }
 
-.site-nav[data-collapsed='true'] {
-  transform: translateY(calc(-100% + 1.8rem));
-  box-shadow: none;
-}
-
+.site-nav[data-collapsed='true'],
 .site-nav[data-collapsed='false'] {
-  transform: translateY(0);
-  box-shadow: 0 14px 40px -28px rgba(25, 63, 96, 0.55);
+  transform: none;
+  box-shadow: 0 18px 44px -30px rgba(25, 63, 96, 0.55);
 }
 
 .site-nav__identity[hidden] {
@@ -144,13 +147,20 @@ textarea {
 
 .site-nav__client {
   display: flex;
-  align-items: center;
+  align-items: stretch;
+  justify-content: space-between;
   gap: 0.75rem;
-  padding: 0.35rem 0.6rem;
-  border-radius: 0.85rem;
-  background: rgba(255, 255, 255, 0.9);
-  border: 1px solid rgba(25, 63, 96, 0.15);
+  flex: 1 1 18rem;
+  min-width: 16rem;
+  padding: 0.75rem 0.85rem;
+  border-radius: 0.95rem;
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(25, 63, 96, 0.18);
   box-shadow: inset 0 1px 0 rgba(25, 63, 96, 0.08);
+}
+
+.site-nav__client > button {
+  align-self: center;
 }
 
 .site-nav__client[hidden] {
@@ -159,8 +169,9 @@ textarea {
 
 .site-nav__client-text {
   display: grid;
-  gap: 0.15rem;
-  min-width: 14rem;
+  gap: 0.25rem;
+  min-width: 0;
+  flex: 1;
 }
 
 .site-nav__client-name {
@@ -190,21 +201,27 @@ textarea {
   text-decoration: underline;
 }
 
+.site-nav__client-discount {
+  margin-top: 0.2rem;
+  width: fit-content;
+}
+
+.site-nav__client-discount[hidden] {
+  display: none !important;
+}
+
 .site-nav__inner {
-  margin: 0 auto;
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
-  max-width: 120rem;
-  padding: 0.85rem 1.5rem;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 0;
+  margin: 0;
 }
 
 .site-nav__branding {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
 }
 
 .brand-logo {
@@ -222,6 +239,32 @@ textarea {
   white-space: nowrap;
 }
 
+.site-nav__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.site-nav__row--identity {
+  justify-content: space-between;
+}
+
+.site-nav__row--toolbar {
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.site-nav__identity-wrapper {
+  display: flex;
+  align-items: stretch;
+  gap: 1rem;
+  flex: 1 1 auto;
+  justify-content: flex-end;
+  min-width: 0;
+}
+
 .site-nav__actions {
   display: flex;
   flex: 1;
@@ -234,11 +277,11 @@ textarea {
 .site-nav__tree {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
-  min-width: 8rem;
-  flex: 0 1 10rem;
-  width: min(100%, 11rem);
-  margin-left: auto;
+  gap: 0.35rem;
+  min-width: 11rem;
+  flex: 0 1 14rem;
+  width: min(100%, 14rem);
+  margin-left: 0;
 }
 
 .site-nav__tree-label {
@@ -287,12 +330,13 @@ textarea {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  min-width: 18rem;
-  flex: 1 1 18rem;
-  padding: 0.65rem 0.85rem;
-  border-radius: 0.9rem;
-  background: rgba(255, 255, 255, 0.85);
-  border: 1px solid rgba(25, 63, 96, 0.1);
+  min-width: 16rem;
+  max-width: 24rem;
+  flex: 1 1 16rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.95rem;
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(25, 63, 96, 0.15);
   position: relative;
 }
 
@@ -361,6 +405,23 @@ textarea {
 .site-nav__identity button[disabled] {
   opacity: 0.6;
   cursor: progress;
+}
+
+.site-nav__toolbar-buttons {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.site-nav__toolbar-secondary {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 .site-nav__cart-actions {
@@ -627,6 +688,23 @@ textarea {
   outline-offset: 2px;
 }
 
+.btn-primary[disabled],
+.btn-secondary[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.btn-primary[disabled]:hover,
+.btn-primary[disabled]:focus-visible,
+.btn-secondary[disabled]:hover,
+.btn-secondary[disabled]:focus-visible {
+  transform: none;
+  box-shadow: none;
+  outline: none;
+}
+
 .btn-icon {
   width: 2.75rem;
   height: 2.75rem;
@@ -744,6 +822,12 @@ textarea {
 .main-layout {
   display: flex;
   gap: 1.5rem;
+}
+
+.catalogue-header {
+  position: sticky;
+  top: 0;
+  z-index: 40;
 }
 
 .split-panel {
@@ -974,7 +1058,7 @@ textarea {
   background: #fff;
   box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
   padding: 1rem;
-  z-index: 30;
+  z-index: 90;
 }
 
 .category-filter-menu[data-open='true'] {
@@ -1772,10 +1856,10 @@ textarea {
 
 .quote-summary-panel {
   position: sticky;
-  top: 0;
+  top: calc(var(--site-nav-height) + 1rem);
   background: linear-gradient(180deg, rgba(237, 237, 237, 0.8), #fff);
   padding-bottom: 1rem;
-  z-index: 10;
+  z-index: 1;
 }
 
 .quote-summary-panel dl {
@@ -1790,61 +1874,35 @@ body[data-viewport-mode='mobile'] .site-nav__inner {
   gap: 1rem;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__inner,
-body[data-viewport-mode='mobile'] .site-nav__inner {
-  display: grid;
-  grid-template-columns: minmax(0, auto) minmax(0, 1fr);
-  align-items: center;
-  width: 100%;
-  gap: 0.75rem;
+body[data-viewport-mode='tablet'] .site-nav__row,
+body[data-viewport-mode='mobile'] .site-nav__row {
+  flex-direction: column;
+  align-items: stretch;
 }
 
-body[data-viewport-mode='mobile'] .site-nav__inner {
-  row-gap: 0.5rem;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__branding,
-body[data-viewport-mode='mobile'] .site-nav__branding {
-  grid-column: 1 / 2;
-}
-
-body[data-viewport-mode='tablet'] .site-nav__actions,
-body[data-viewport-mode='mobile'] .site-nav__actions {
-  grid-column: 2 / 3;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.5rem;
-  width: 100%;
-}
-
-body[data-viewport-mode='mobile'] .site-nav__actions {
-  row-gap: 0.35rem;
+body[data-viewport-mode='tablet'] .site-nav__identity-wrapper,
+body[data-viewport-mode='mobile'] .site-nav__identity-wrapper {
+  flex-direction: column;
+  align-items: stretch;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__identity,
 body[data-viewport-mode='mobile'] .site-nav__identity,
 body[data-viewport-mode='tablet'] .site-nav__client,
 body[data-viewport-mode='mobile'] .site-nav__client {
-  margin-right: auto;
-  flex: 0 1 15rem;
-  min-width: 9rem;
+  flex: 1 1 100%;
+  max-width: none;
+  min-width: 0;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__client,
 body[data-viewport-mode='mobile'] .site-nav__client {
-  order: -1;
-  padding: 0.5rem 0.65rem;
-  gap: 0.5rem;
+  order: initial;
 }
 
-body[data-viewport-mode='tablet'] .site-nav__identity,
-body[data-viewport-mode='mobile'] .site-nav__identity {
-  padding: 0;
-  background: transparent;
-  border: none;
-  box-shadow: none;
+body[data-viewport-mode='tablet'] .site-nav__toolbar-secondary,
+body[data-viewport-mode='mobile'] .site-nav__toolbar-secondary {
+  justify-content: flex-start;
 }
 
 body[data-viewport-mode='tablet'] .site-nav__identity-controls,
@@ -1974,21 +2032,28 @@ body[data-viewport-mode='tablet'][data-mobile-view='footer'] .site-nav__mobile-t
 
 @media (max-width: 768px) {
   .site-nav__inner {
-    flex-direction: column;
-    align-items: flex-start;
+    gap: 1rem;
   }
 
-  .site-nav__actions {
+  .site-nav__identity,
+  .site-nav__client,
+  .site-nav__tree {
+    width: 100%;
+  }
+
+  .site-nav__toolbar-buttons,
+  .site-nav__toolbar-secondary {
     width: 100%;
     justify-content: flex-start;
   }
 
-  .site-nav__identity,
-  .site-nav__cart-actions,
-  .site-nav__tree {
+  .site-nav__toolbar-buttons {
+    gap: 0.65rem;
+  }
+
+  .site-nav__toolbar-buttons .btn-primary,
+  .site-nav__toolbar-secondary .btn-secondary {
     width: 100%;
-    flex: 1 1 100%;
-    margin-left: 0;
   }
 
   #main-layout {
@@ -2002,23 +2067,27 @@ body[data-viewport-mode='tablet'][data-mobile-view='footer'] .site-nav__mobile-t
 }
 
 @media (max-width: 640px) {
-  .site-nav__actions {
-    flex-direction: column;
-    align-items: stretch;
+  .site-nav__toolbar-buttons,
+  .site-nav__toolbar-secondary {
     gap: 0.5rem;
-  }
-
-  .site-nav__actions .btn-primary {
-    width: 100%;
-  }
-
-  .site-nav__cart-actions {
-    flex-direction: column;
     align-items: stretch;
   }
 
-  .site-nav__cart-actions .btn-secondary {
+  .site-nav__toolbar-buttons .btn-icon,
+  .site-nav__toolbar-buttons .btn-primary,
+  .site-nav__toolbar-secondary .btn-secondary,
+  .site-nav__toolbar-secondary .site-nav__mobile-toggle,
+  .site-nav__toolbar-secondary .site-nav__tree {
     width: 100%;
+  }
+
+  .viewport-toggle {
+    width: 100%;
+  }
+
+  .viewport-toggle__button {
+    width: 100%;
+    justify-content: center;
   }
 
   .product-card {

--- a/index.html
+++ b/index.html
@@ -18,226 +18,7 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <nav class="site-nav fixed inset-x-0 top-0 z-40" data-collapsed="false">
-      <div class="site-nav__inner">
-        <div class="site-nav__branding">
-          <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
-          <p class="brand-title">ID GROUP</p>
-        </div>
-        <div class="site-nav__actions">
-          <form id="siret-form" class="site-nav__identity" autocomplete="off">
-            <label for="siret-input" class="site-nav__identity-label">SIRET</label>
-            <div class="site-nav__identity-controls">
-              <input
-                id="siret-input"
-                name="siret"
-                type="text"
-                inputmode="numeric"
-                maxlength="14"
-                placeholder="Numéro SIRET (14 chiffres)"
-                class="site-nav__identity-input"
-              />
-              <button
-                id="siret-submit"
-                type="submit"
-                class="btn-secondary btn-icon"
-                data-tooltip="Identifier le client"
-                aria-label="Identifier le client"
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                  <path
-                    d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
-                    fill="none"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-                <span class="sr-only">Identifier</span>
-              </button>
-            </div>
-            <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
-          </form>
-          <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
-            <div class="site-nav__client-text">
-              <p id="client-identity-name" class="site-nav__client-name"></p>
-              <p id="client-identity-meta" class="site-nav__client-meta"></p>
-              <p id="client-identity-register" class="site-nav__client-register">
-                <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
-                  >S'enregistrer comme nouveau client</a
-                >
-              </p>
-            </div>
-            <button
-              id="client-identity-reset"
-              type="button"
-              class="btn-secondary btn-secondary--compact btn-icon"
-              data-tooltip="Modifier l'identification"
-              aria-label="Modifier l'identification"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
-                  fill="currentColor"
-                />
-              </svg>
-              <span class="sr-only">Modifier</span>
-            </button>
-          </div>
-          <div class="site-nav__cart-actions">
-            <button
-              id="save-cart"
-              type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Sauvegarder le panier"
-              aria-label="Sauvegarder le panier"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 3h6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M9 13h6v6H9z"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Sauvegarder</span>
-            </button>
-            <button
-              id="restore-cart"
-              type="button"
-              class="btn-secondary btn-icon"
-              data-tooltip="Restaurer une sauvegarde"
-              aria-label="Restaurer une sauvegarde"
-            >
-              <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-                <path
-                  d="M4 4v6h6M20 20v-6h-6"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-                <path
-                  d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                />
-              </svg>
-              <span class="sr-only">Restaurer</span>
-            </button>
-            <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
-          </div>
-          <button
-            id="mobile-view-toggle"
-            type="button"
-            class="btn-secondary btn-secondary--compact site-nav__mobile-toggle"
-            aria-pressed="false"
-          >
-            <span id="mobile-view-toggle-label" class="site-nav__mobile-toggle-label">Voir le pied de page</span>
-          </button>
-          <div class="viewport-toggle" data-mode="desktop">
-            <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
-              <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
-                <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
-                <rect
-                  data-role="viewport-stand"
-                  class="viewport-toggle__icon-stand"
-                  x="12"
-                  y="26"
-                  width="8"
-                  height="2"
-                  rx="1"
-                  ry="1"
-                />
-              </svg>
-              <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
-            </button>
-          </div>
-          <div class="discount-field" aria-live="polite">
-            <span>Remise</span>
-            <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
-          </div>
-          <button
-            id="generate-pdf"
-            class="btn-primary btn-icon"
-            data-tooltip="Imprimer le devis"
-            aria-label="Imprimer le devis"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <path
-                d="M7 13h10v8H7z"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-            </svg>
-            <span class="sr-only">Imprimer</span>
-          </button>
-          <button
-            id="submit-order"
-            class="btn-primary btn-icon"
-            data-tooltip="Passer commande"
-            aria-label="Passer commande"
-            type="button"
-          >
-            <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
-              <path
-                d="M3 5h2l2 12h12l2-8H6"
-                fill="none"
-                stroke="currentColor"
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-              />
-              <circle cx="9" cy="19" r="1.5" fill="currentColor" />
-              <circle cx="18" cy="19" r="1.5" fill="currentColor" />
-            </svg>
-            <span class="sr-only">Passer commande</span>
-          </button>
-          <div class="site-nav__tree">
-            <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
-            <select id="catalogue-tree" class="site-nav__tree-select">
-              <option value="">Sélectionner une catégorie ou un article</option>
-            </select>
-          </div>
-        </div>
-      </div>
-    </nav>
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-28">
+    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-12">
       <div id="main-layout" class="main-layout">
         <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
           <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
@@ -304,6 +85,236 @@
           <div id="product-grid" class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>
         </section>
         <aside id="quote-panel" class="split-panel rounded-2xl bg-white p-6 shadow-lg brand-surface">
+          <nav class="site-nav" data-collapsed="false">
+            <div class="site-nav__inner">
+              <div class="site-nav__row site-nav__row--identity">
+                <div class="site-nav__branding">
+                  <img src="media/ID GROUP.png" alt="ID Group" class="brand-logo" />
+                  <p class="brand-title">ID GROUP</p>
+                </div>
+                <div class="site-nav__identity-wrapper">
+                  <form id="siret-form" class="site-nav__identity" autocomplete="off">
+                    <label for="siret-input" class="site-nav__identity-label">SIRET</label>
+                    <div class="site-nav__identity-controls">
+                      <input
+                        id="siret-input"
+                        name="siret"
+                        type="text"
+                        inputmode="numeric"
+                        maxlength="14"
+                        placeholder="Numéro SIRET (14 chiffres)"
+                        class="site-nav__identity-input"
+                      />
+                      <button
+                        id="siret-submit"
+                        type="submit"
+                        class="btn-secondary btn-icon"
+                        data-tooltip="Identifier le client"
+                        aria-label="Identifier le client"
+                      >
+                        <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                          <path
+                            d="M21 21l-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                        <span class="sr-only">Identifier</span>
+                      </button>
+                    </div>
+                    <p id="siret-feedback" class="site-nav__identity-feedback" aria-live="polite"></p>
+                  </form>
+                  <div id="client-identity" class="site-nav__client" aria-live="polite" hidden>
+                    <div class="site-nav__client-text">
+                      <p id="client-identity-name" class="site-nav__client-name"></p>
+                      <p id="client-identity-meta" class="site-nav__client-meta"></p>
+                      <div
+                        id="client-identity-discount"
+                        class="site-nav__client-discount discount-field"
+                        aria-live="polite"
+                        hidden
+                      >
+                        <span>Remise</span>
+                        <span id="header-discount" class="discount-field__value">0&nbsp;%</span>
+                      </div>
+                      <p id="client-identity-register" class="site-nav__client-register">
+                        <a href="https://www.idgroup-france.com/bao/NouveauClient.html" target="_blank" rel="noopener"
+                          >S'enregistrer comme nouveau client</a
+                        >
+                      </p>
+                    </div>
+                    <button
+                      id="client-identity-reset"
+                      type="button"
+                      class="btn-secondary btn-secondary--compact btn-icon"
+                      data-tooltip="Modifier l'identification"
+                      aria-label="Modifier l'identification"
+                    >
+                      <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                        <path
+                          d="M3 17.25V21h3.75L17.81 9.94l-3.75-3.75L3 17.25Zm14.71-9.54a1 1 0 0 0 0-1.41l-2.54-2.54a1 1 0 0 0-1.41 0L12 5.56l3.75 3.75 1.96-1.6Z"
+                          fill="currentColor"
+                        />
+                      </svg>
+                      <span class="sr-only">Modifier</span>
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div class="site-nav__row site-nav__row--toolbar">
+                <div class="site-nav__toolbar-buttons">
+                  <button
+                    id="save-cart"
+                    type="button"
+                    class="btn-secondary btn-icon"
+                    data-tooltip="Sauvegarder le panier"
+                    aria-label="Sauvegarder le panier"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M7 4h10l3 3v13a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Zm5 0v5"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M9 3h6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M9 13h6v6H9z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                    <span class="sr-only">Sauvegarder</span>
+                  </button>
+                  <button
+                    id="restore-cart"
+                    type="button"
+                    class="btn-secondary btn-icon"
+                    data-tooltip="Restaurer une sauvegarde"
+                    aria-label="Restaurer une sauvegarde"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M4 4v6h6M20 20v-6h-6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M19 5a8.5 8.5 0 0 0-14.5 6.36M5 19a8.5 8.5 0 0 0 14.5-6.36"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                    <span class="sr-only">Restaurer</span>
+                  </button>
+                  <input id="restore-cart-input" type="file" accept="application/json" class="sr-only" />
+                  <div class="viewport-toggle" data-mode="desktop">
+                    <button id="viewport-mode-toggle" type="button" class="viewport-toggle__button">
+                      <svg aria-hidden="true" class="viewport-toggle__icon" viewBox="0 0 32 32">
+                        <rect data-role="viewport-screen" x="3" y="6" width="26" height="20" rx="3" ry="3" />
+                        <rect
+                          data-role="viewport-stand"
+                          class="viewport-toggle__icon-stand"
+                          x="12"
+                          y="26"
+                          width="8"
+                          height="2"
+                          rx="1"
+                          ry="1"
+                        />
+                      </svg>
+                      <span id="viewport-mode-label" class="viewport-toggle__label">Mode : Bureau</span>
+                    </button>
+                  </div>
+                  <button
+                    id="generate-pdf"
+                    class="btn-primary btn-icon"
+                    data-tooltip="Imprimer le devis"
+                    aria-label="Imprimer le devis"
+                    type="button"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M7 9V3h10v6M7 17H5a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2h-2"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <path
+                        d="M7 13h10v8H7z"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                    </svg>
+                    <span class="sr-only">Imprimer</span>
+                  </button>
+                  <button
+                    id="submit-order"
+                    class="btn-primary btn-icon"
+                    data-tooltip="Passer commande"
+                    aria-label="Passer commande"
+                    type="button"
+                  >
+                    <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                      <path
+                        d="M3 5h2l2 12h12l2-8H6"
+                        fill="none"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                      />
+                      <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                      <circle cx="18" cy="19" r="1.5" fill="currentColor" />
+                    </svg>
+                    <span class="sr-only">Passer commande</span>
+                  </button>
+                </div>
+                <div class="site-nav__toolbar-secondary">
+                  <button
+                    id="mobile-view-toggle"
+                    type="button"
+                    class="btn-secondary btn-secondary--compact site-nav__mobile-toggle"
+                    aria-pressed="false"
+                  >
+                    <span id="mobile-view-toggle-label" class="site-nav__mobile-toggle-label">Voir le pied de page</span>
+                  </button>
+                  <div class="site-nav__tree">
+                    <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
+                    <select id="catalogue-tree" class="site-nav__tree-select">
+                      <option value="">Sélectionner une catégorie ou un article</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </nav>
           <footer class="quote-summary-panel border-b border-slate-200 pb-4">
             <dl class="space-y-2 text-sm text-slate-600">
               <div class="flex items-center justify-between">


### PR DESCRIPTION
## Résumé
- repositionne le menu principal dans l’aside de droite avec les nouvelles rangées et affichages de remise
- rend l’en-tête du catalogue sticky et corrige l’empilement du filtre catégorie
- interdit le passage de commande tant que le client n’est pas identifié et véhicule l’id client dans les sauvegardes et webhooks

## Tests
- Aucun test automatisé (non applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e75cc98538832999989043f1f1aa65