### PR TITLE
Réorganisation des colonnes et réglages de grille

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -216,6 +216,13 @@ textarea {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  cursor: pointer;
+}
+
+.site-nav__branding:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 4px;
+  border-radius: 0.75rem;
 }
 
 .site-nav__branding-text {
@@ -310,30 +317,10 @@ textarea {
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.webhook-mode-badge {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-left: 0.5rem;
-  padding: 0.25rem 0.65rem;
-  border-radius: 9999px;
-  background: rgba(25, 63, 96, 0.08);
-  color: var(--color-secondary);
-  font-size: 0.7rem;
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border: 1px solid rgba(25, 63, 96, 0.12);
-}
-
-.webhook-mode-badge:empty {
-  display: none;
-}
-
+.webhook-mode-badge,
+.webhook-mode-badge:empty,
 .webhook-mode-badge[data-mode='test'] {
-  background: rgba(234, 97, 26, 0.12);
-  border-color: rgba(234, 97, 26, 0.35);
-  color: var(--color-accent);
+  display: none !important;
 }
 
 .site-nav__identity {
@@ -898,6 +885,19 @@ textarea {
   border: 1px solid rgba(234, 97, 26, 0.35);
 }
 
+.product-grid {
+  --product-columns: 3;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(1, minmax(0, 1fr));
+}
+
+@media (min-width: 640px) {
+  .product-grid {
+    grid-template-columns: repeat(clamp(2, var(--product-columns, 3), 5), minmax(0, 1fr));
+  }
+}
+
 #quote-empty {
   border-color: rgba(25, 63, 96, 0.2);
   background: rgba(25, 63, 96, 0.05);
@@ -1052,7 +1052,7 @@ textarea {
   background: #fff;
   box-shadow: 0 20px 45px -20px rgba(25, 63, 96, 0.35);
   padding: 1rem;
-  z-index: 80;
+  z-index: 200;
 }
 
 .category-filter-menu[data-open='true'] {

--- a/index.html
+++ b/index.html
@@ -18,72 +18,8 @@
     <script src="js/app.js" type="module" defer></script>
   </head>
   <body class="site-body min-h-screen">
-    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24 pt-10">
+    <main class="mx-auto w-full max-w-[120rem] px-4 pb-24">
       <div id="main-layout" class="main-layout">
-        <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
-          <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
-            <div>
-              <h1 id="catalogue-title" class="text-2xl font-semibold text-slate-900 brand-heading">Catalogue produits</h1>
-              <p class="mt-1 text-sm text-slate-500 brand-text-muted">
-                Parcourez le catalogue et ajoutez les articles souhaités directement à votre devis.
-              </p>
-            </div>
-            <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
-              <div class="relative w-full lg:max-w-md">
-                <label for="search" class="sr-only">Rechercher un produit</label>
-                <input
-                  id="search"
-                  type="search"
-                  placeholder="Rechercher par nom ou référence..."
-                  class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-11 pr-4 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 brand-input"
-                />
-                <svg class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
-                </svg>
-              </div>
-              <div class="flex flex-col gap-3 sm:flex-row sm:items-center xl:w-auto">
-                <div class="relative sm:w-56 xl:w-64">
-                  <button
-                    id="category-filter-button"
-                    type="button"
-                  class="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition hover:border-blue-300 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 brand-select"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                  >
-                    <span id="category-filter-label">Toutes les catégories</span>
-                    <svg class="h-4 w-4 text-slate-400 transition-transform" data-role="chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.5 8.25 12 15.75 4.5 8.25" />
-                    </svg>
-                  </button>
-                  <div
-                    id="category-filter-menu"
-                    class="category-filter-menu"
-                    role="menu"
-                    aria-labelledby="category-filter-button"
-                  >
-                    <div class="category-filter-header">
-                      <p class="text-sm font-semibold text-slate-900">Catégories</p>
-                      <button id="category-filter-clear" type="button" class="text-xs font-semibold text-blue-600 transition hover:text-blue-700">Réinitialiser</button>
-                    </div>
-                    <div id="category-filter-options" class="category-filter-options" role="group" aria-label="Filtrer par catégories"></div>
-                    <div class="category-filter-footer">
-                      <p class="text-xs text-slate-500">Sélectionnez une ou plusieurs catégories pour affiner la liste.</p>
-                      <button id="category-filter-close" type="button" class="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100">Fermer</button>
-                    </div>
-                  </div>
-                </div>
-                <label for="unit-filter" class="flex flex-1 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition focus-within:border-blue-300 focus-within:bg-white focus-within:ring-2 focus-within:ring-blue-500/20 brand-select">
-                  <span class="text-xs uppercase tracking-wide text-slate-500">Unité</span>
-                  <select id="unit-filter" class="w-full rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
-                    <option value="">Toutes les unités</option>
-                  </select>
-                </label>
-              </div>
-            </div>
-          </header>
-          <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
-          <div id="product-grid" class="grid grid-cols-1 gap-5 sm:grid-cols-2 xl:grid-cols-3"></div>
-        </section>
         <aside id="quote-panel" class="split-panel rounded-2xl bg-white p-0 shadow-lg brand-surface">
           <nav class="site-nav" data-collapsed="false">
             <div class="site-nav__inner">
@@ -312,7 +248,7 @@
               </div>
             </div>
           </nav>
-          <div class="site-nav__tree">
+          <div class="site-nav__tree" hidden>
             <label for="catalogue-tree" class="site-nav__tree-label">Catégories</label>
             <select id="catalogue-tree" class="site-nav__tree-select">
               <option value="">Sélectionner une catégorie ou un article</option>
@@ -375,6 +311,79 @@
             </div>
           </div>
         </aside>
+        <section id="catalogue-panel" aria-labelledby="catalogue-title" class="split-panel gap-6">
+          <header class="catalogue-header flex flex-col gap-4 rounded-2xl bg-white p-6 shadow-sm brand-surface">
+            <div>
+              <h1 id="catalogue-title" class="text-2xl font-semibold text-slate-900 brand-heading">Catalogue produits</h1>
+              <p class="mt-1 text-sm text-slate-500 brand-text-muted">
+                Parcourez le catalogue et ajoutez les articles souhaités directement à votre devis.
+              </p>
+            </div>
+            <div class="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
+              <div class="relative w-full lg:max-w-md">
+                <label for="search" class="sr-only">Rechercher un produit</label>
+                <input
+                  id="search"
+                  type="search"
+                  placeholder="Rechercher par nom ou référence..."
+                  class="w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-11 pr-4 text-sm text-slate-700 shadow-inner focus:border-blue-500 focus:bg-white focus:outline-none focus:ring-2 focus:ring-blue-500/20 brand-input"
+                />
+                <svg class="pointer-events-none absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-slate-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="m21 21-4.35-4.35m0 0a7 7 0 1 0-9.9-9.9 7 7 0 0 0 9.9 9.9Z" />
+                </svg>
+              </div>
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center xl:w-auto">
+                <div class="relative sm:w-56 xl:w-64">
+                  <button
+                    id="category-filter-button"
+                    type="button"
+                  class="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition hover:border-blue-300 hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500 brand-select"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                  >
+                    <span id="category-filter-label">Toutes les catégories</span>
+                    <svg class="h-4 w-4 text-slate-400 transition-transform" data-role="chevron" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.5 8.25 12 15.75 4.5 8.25" />
+                    </svg>
+                  </button>
+                  <div
+                    id="category-filter-menu"
+                    class="category-filter-menu"
+                    role="menu"
+                    aria-labelledby="category-filter-button"
+                  >
+                    <div class="category-filter-header">
+                      <p class="text-sm font-semibold text-slate-900">Catégories</p>
+                      <button id="category-filter-clear" type="button" class="text-xs font-semibold text-blue-600 transition hover:text-blue-700">Réinitialiser</button>
+                    </div>
+                    <div id="category-filter-options" class="category-filter-options" role="group" aria-label="Filtrer par catégories"></div>
+                    <div class="category-filter-footer">
+                      <p class="text-xs text-slate-500">Sélectionnez une ou plusieurs catégories pour affiner la liste.</p>
+                      <button id="category-filter-close" type="button" class="rounded-lg border border-slate-200 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100">Fermer</button>
+                    </div>
+                  </div>
+                </div>
+                <label for="unit-filter" class="flex flex-1 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition focus-within:border-blue-300 focus-within:bg-white focus-within:ring-2 focus-within:ring-blue-500/20 brand-select">
+                  <span class="text-xs uppercase tracking-wide text-slate-500">Unité</span>
+                  <select id="unit-filter" class="w-full rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
+                    <option value="">Toutes les unités</option>
+                  </select>
+                </label>
+                <label for="product-columns" class="flex flex-1 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition focus-within:border-blue-300 focus-within:bg-white focus-within:ring-2 focus-within:ring-blue-500/20 brand-select">
+                  <span class="text-xs uppercase tracking-wide text-slate-500">Colonnes</span>
+                  <select id="product-columns" class="w-full rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
+                    <option value="2">2 colonnes</option>
+                    <option value="3" selected>3 colonnes</option>
+                    <option value="4">4 colonnes</option>
+                    <option value="5">5 colonnes</option>
+                  </select>
+                </label>
+              </div>
+            </div>
+          </header>
+          <div id="product-feedback" class="hidden rounded-2xl bg-amber-50 px-6 py-4 text-sm text-amber-700 shadow-sm"></div>
+          <div id="product-grid" class="product-grid"></div>
+        </section>
       </div>
     </main>
 


### PR DESCRIPTION
## Résumé
- inversion des panneaux pour afficher le devis à gauche et le catalogue à droite sans marge haute
- masquage permanent du badge webhook et mise en avant du menu des catégories, avec navigation pliable sur le logo
- ajout d’un sélecteur de colonnes pour la grille produits et adaptation dynamique de la mise en page

## Tests
- aucun test automatisé n’a été exécuté

------
https://chatgpt.com/codex/tasks/task_b_68e792381dac8329bac22fbbae61ffc9