### PR TITLE
Améliore les actions des produits et la gestion des filtres

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -590,7 +590,7 @@ textarea {
   z-index: 10;
   backdrop-filter: blur(6px);
   isolation: isolate;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .catalogue-header::before {

--- a/index.html
+++ b/index.html
@@ -300,7 +300,7 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6l4 2" />
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5h15a1.5 1.5 0 0 0 1.5-1.5v-12A1.5 1.5 0 0 0 19.5 4.5h-15A1.5 1.5 0 0 0 3 6v12a1.5 1.5 0 0 0 1.5 1.5Z" />
               </svg>
-              <p>Aucun article n'a encore été ajouté. Utilisez le bouton « Ajouter au devis » sur un produit.</p>
+              <p>Aucun article n'a encore été ajouté. Utilisez l'icône panier sur un produit pour l'ajouter au devis.</p>
             </div>
             <div id="quote-list" class="mt-4 hidden flex-1 space-y-4 overflow-y-auto pr-1"></div>
             <div class="mt-6 space-y-4">
@@ -366,9 +366,16 @@
                 <label for="unit-filter" class="flex flex-1 items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition focus-within:border-blue-300 focus-within:bg-white focus-within:ring-2 focus-within:ring-blue-500/20 brand-select">
                   <span class="text-xs uppercase tracking-wide text-slate-500">Unité</span>
                   <select id="unit-filter" class="w-full rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
-                    <option value="">Toutes les unités</option>
+                    <option value="__all__">Toutes les unités</option>
                   </select>
                 </label>
+                <button
+                  id="clear-all-filters"
+                  type="button"
+                  class="flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-semibold text-slate-600 shadow-sm transition hover:border-blue-300 hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                  Supprimer tous les filtres
+                </button>
                 <label for="product-grid-columns" class="flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-700 shadow-inner transition focus-within:border-blue-300 focus-within:bg-white focus-within:ring-2 focus-within:ring-blue-500/20 brand-select">
                   <span class="text-xs uppercase tracking-wide text-slate-500">Colonnes</span>
                   <select id="product-grid-columns" class="w-24 rounded-lg border border-slate-200 bg-white px-2 py-1 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20">
@@ -413,11 +420,34 @@
               <p class="product-weight text-xs text-slate-400"></p>
             </div>
             <div class="flex flex-col items-end gap-2">
-              <button class="view-details btn-secondary">
-                Voir les détails
+              <button class="view-details btn-secondary btn-icon" type="button">
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M2.25 12s3.75-6.75 9.75-6.75S21.75 12 21.75 12 18 18.75 12 18.75 2.25 12 2.25 12Z"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <circle cx="12" cy="12" r="2.25" fill="none" stroke="currentColor" stroke-width="1.5" />
+                </svg>
+                <span class="sr-only">Voir les détails</span>
               </button>
-              <button class="add-to-quote btn-primary">
-                Ajouter au devis
+              <button class="add-to-quote btn-primary btn-icon" type="button">
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M3 5h2l2 12h12l2-8H6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                  <circle cx="18" cy="19" r="1.5" fill="currentColor" />
+                </svg>
+                <span class="sr-only">Ajouter au devis</span>
               </button>
             </div>
           </div>

--- a/js/app.js
+++ b/js/app.js
@@ -129,6 +129,7 @@ const elements = {
   categoryFilterOptions: document.getElementById('category-filter-options'),
   categoryFilterClear: document.getElementById('category-filter-clear'),
   categoryFilterClose: document.getElementById('category-filter-close'),
+  clearAllFilters: document.getElementById('clear-all-filters'),
   catalogueTree: document.getElementById('catalogue-tree'),
   productGrid: document.getElementById('product-grid'),
   productGridColumns: document.getElementById('product-grid-columns'),
@@ -217,6 +218,7 @@ document.addEventListener('DOMContentLoaded', () => {
   loadCatalogue();
   elements.search?.addEventListener('input', handleSearch);
   elements.unitFilter?.addEventListener('change', handleUnitFilterChange);
+  elements.clearAllFilters?.addEventListener('click', handleClearAllFilters);
   elements.generalComment?.addEventListener('input', handleGeneralCommentChange);
   elements.generatePdf?.addEventListener('click', generatePdf);
   elements.submitOrder?.addEventListener('click', handleSubmitOrderClick);
@@ -790,6 +792,38 @@ function handleSearch(event) {
   const query = event.target.value.trim().toLowerCase();
   state.searchQuery = query;
   applyFilters();
+}
+
+function handleClearAllFilters(event) {
+  if (event && typeof event.preventDefault === 'function') {
+    event.preventDefault();
+  }
+  clearAllFilters();
+  closeCategoryMenu();
+}
+
+function clearAllFilters() {
+  const hadQuery = state.searchQuery.length > 0;
+  const hadCategories = state.selectedCategories.size > 0;
+  const hadUnit = state.selectedUnit !== UNIT_FILTER_ALL;
+
+  state.searchQuery = '';
+  if (elements.search) {
+    elements.search.value = '';
+  }
+
+  if (hadCategories) {
+    setCategorySelection([]);
+  }
+
+  state.selectedUnit = UNIT_FILTER_ALL;
+  if (elements.unitFilter) {
+    elements.unitFilter.value = UNIT_FILTER_ALL;
+  }
+
+  if (hadQuery || hadCategories || hadUnit) {
+    applyFilters();
+  }
 }
 
 function applyFilters() {


### PR DESCRIPTION
## Summary
- remplace les actions textuelles des cartes produits par des icônes dédiées et ajuste le texte d’aide du devis vide
- ajoute un bouton « Supprimer tous les filtres » et la logique associée pour réinitialiser recherche, catégories et unité
- laisse le menu des catégories s’afficher au-dessus des tuiles produits en supprimant le masquage par overflow de l’entête

## Testing
- [x] `python -m http.server 8000`


------
https://chatgpt.com/codex/tasks/task_b_68e7bf27d2088329960d8cccc80dd5f5