### PR TITLE
Ajout d'icônes aux cartes produit et réinitialisation des filtres

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -587,10 +587,10 @@ textarea {
 .catalogue-header {
   position: sticky;
   top: calc(var(--site-nav-height) + 1rem);
-  z-index: 10;
+  z-index: 40;
   backdrop-filter: blur(6px);
   isolation: isolate;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .catalogue-header::before {

--- a/index.html
+++ b/index.html
@@ -378,6 +378,23 @@
                     <option value="5">5</option>
                   </select>
                 </label>
+                <button
+                  id="reset-filters"
+                  type="button"
+                  class="btn-secondary btn-secondary--compact flex items-center gap-2 self-start sm:self-auto"
+                >
+                  <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                    <path
+                      d="M4 4h6M4 10h10M4 16h6M15 16l3 3 3-3M21 7l-3-3-3 3"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="1.5"
+                    />
+                  </svg>
+                  <span>Supprimer les filtres</span>
+                </button>
               </div>
             </div>
           </header>
@@ -413,11 +430,41 @@
               <p class="product-weight text-xs text-slate-400"></p>
             </div>
             <div class="flex flex-col items-end gap-2">
-              <button class="view-details btn-secondary">
-                Voir les détails
+              <button class="view-details btn-secondary btn-icon" type="button" aria-label="Voir les détails">
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M2.25 12c1.8-4 5.48-6.75 9.75-6.75s7.95 2.75 9.75 6.75c-1.8 4-5.48 6.75-9.75 6.75S4.05 16 2.25 12Z"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <path
+                    d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                </svg>
+                <span class="sr-only">Voir les détails</span>
               </button>
-              <button class="add-to-quote btn-primary">
-                Ajouter au devis
+              <button class="add-to-quote btn-primary btn-icon" type="button" aria-label="Ajouter au devis">
+                <svg aria-hidden="true" viewBox="0 0 24 24" class="icon">
+                  <path
+                    d="M3 5h2l2 12h12l2-8H6"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1.5"
+                  />
+                  <circle cx="9" cy="19" r="1.5" fill="currentColor" />
+                  <circle cx="18" cy="19" r="1.5" fill="currentColor" />
+                </svg>
+                <span class="sr-only">Ajouter au devis</span>
               </button>
             </div>
           </div>

--- a/js/app.js
+++ b/js/app.js
@@ -129,6 +129,7 @@ const elements = {
   categoryFilterOptions: document.getElementById('category-filter-options'),
   categoryFilterClear: document.getElementById('category-filter-clear'),
   categoryFilterClose: document.getElementById('category-filter-close'),
+  resetFilters: document.getElementById('reset-filters'),
   catalogueTree: document.getElementById('catalogue-tree'),
   productGrid: document.getElementById('product-grid'),
   productGridColumns: document.getElementById('product-grid-columns'),
@@ -236,6 +237,7 @@ document.addEventListener('DOMContentLoaded', () => {
   elements.viewportToggle?.addEventListener('click', handleViewportToggleClick);
   elements.mobileViewToggle?.addEventListener('click', handleMobileViewToggleClick);
   elements.webhookPanelClose?.addEventListener('click', closeWebhookPanel);
+  elements.resetFilters?.addEventListener('click', handleResetFilters);
   elements.clientIdentityReset?.addEventListener('click', handleClientIdentityReset);
   elements.siretErrorClose?.addEventListener('click', closeSiretErrorModal);
   elements.siretErrorModal?.addEventListener('click', handleSiretErrorBackdropClick);
@@ -3844,6 +3846,27 @@ function buildCatalogueTree(items) {
 function handleUnitFilterChange(event) {
   const value = event.target?.value ?? UNIT_FILTER_ALL;
   state.selectedUnit = value;
+  applyFilters();
+}
+
+function handleResetFilters() {
+  resetAllFilters();
+}
+
+function resetAllFilters() {
+  state.searchQuery = '';
+  if (elements.search) {
+    elements.search.value = '';
+  }
+  state.selectedUnit = UNIT_FILTER_ALL;
+  if (elements.unitFilter) {
+    elements.unitFilter.value = UNIT_FILTER_ALL;
+  }
+  if (elements.catalogueTree) {
+    elements.catalogueTree.value = '';
+  }
+  setCategorySelection([]);
+  closeCategoryMenu();
   applyFilters();
 }
 


### PR DESCRIPTION
## Summary
- remplace les libellés textuels des cartes produit par des icônes dédiées
- ajoute un bouton pour supprimer l'ensemble des filtres du catalogue et la logique de réinitialisation
- corrige la superposition du menu de filtres de catégorie en l'affichant au premier plan

## Testing
- not run (non applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e7bf27d2088329960d8cccc80dd5f5